### PR TITLE
DS-187 - menu accessibility fixes

### DIFF
--- a/src/components/Forms/Actions/Menu/index.tsx
+++ b/src/components/Forms/Actions/Menu/index.tsx
@@ -28,6 +28,8 @@ const MenuItem = ({
       css={menuItemContainerStyles}
       value={item.value || item.label || ''}
       disabled={item.disabled}
+      role='menuitem'
+      aria-label={item.label}
     >
       {item.children ? (
         item.children
@@ -43,7 +45,9 @@ const MenuItem = ({
             <div css={menuItemLabelContentStyles}>
               <p className='menu-item-label'>{item.label}</p>
               {item.command ? (
-                <ChakraMenu.ItemCommand>{item.command}</ChakraMenu.ItemCommand>
+                <ChakraMenu.ItemCommand aria-label={`Shortcut ${item.command}`}>
+                  {item.command}
+                </ChakraMenu.ItemCommand>
               ) : null}
             </div>
             {item.caption ? (
@@ -84,16 +88,28 @@ const Menu = ({ label, items, groups, onSelect, customTrigger }: MenuProps) => {
       </ChakraMenu.Trigger>
       <Portal>
         <ChakraMenu.Positioner>
-          <ChakraMenu.Content css={menuContentStyles}>
+          <ChakraMenu.Content
+            css={menuContentStyles}
+            role='menu'
+            aria-label={label || 'Menu'}
+          >
             {items?.map((item, idx) => {
               if (item.submenu) {
+                const [submenuOpen, setSubmenuOpen] = useState(false)
                 return (
                   <ChakraMenu.Root
                     key={`${item.value}-${idx}`}
                     positioning={{ placement: 'right-start', gutter: 2 }}
                     onSelect={({ value }) => onSelect && onSelect(value)}
+                    onOpenChange={({ open }) => setSubmenuOpen(open)}
+                    open={submenuOpen}
                   >
-                    <ChakraMenu.TriggerItem css={menuSubmenuTriggerStyles}>
+                    <ChakraMenu.TriggerItem
+                      css={menuSubmenuTriggerStyles}
+                      role='menuitem'
+                      aria-haspopup='true'
+                      aria-expanded={submenuOpen ? 'true' : 'false'}
+                    >
                       {item.label}{' '}
                       <ChevronDownIcon
                         rotate='270'
@@ -102,7 +118,11 @@ const Menu = ({ label, items, groups, onSelect, customTrigger }: MenuProps) => {
                     </ChakraMenu.TriggerItem>
                     <Portal>
                       <ChakraMenu.Positioner>
-                        <ChakraMenu.Content css={menuContentStyles}>
+                        <ChakraMenu.Content
+                          css={menuContentStyles}
+                          role='menu'
+                          aria-label={`${item.label} submenu`}
+                        >
                           {item.submenu.map((submenuItem, submenuIdx) => (
                             <MenuItem
                               key={submenuItem.value}
@@ -130,8 +150,14 @@ const Menu = ({ label, items, groups, onSelect, customTrigger }: MenuProps) => {
 
             {groups?.map((group, idx) => (
               <React.Fragment key={group.title}>
-                <ChakraMenu.ItemGroup>
-                  <ChakraMenu.ItemGroupLabel css={menuItemGroupLabelStyles}>
+                <ChakraMenu.ItemGroup
+                  role='group'
+                  aria-labelledby={`group-${idx}`}
+                >
+                  <ChakraMenu.ItemGroupLabel
+                    id={`group-${idx}`}
+                    css={menuItemGroupLabelStyles}
+                  >
                     {group.title}
                   </ChakraMenu.ItemGroupLabel>
                   {group.items?.map((groupItem) => (


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Make sure you are requesting to pull a topic/feature/bugfix branch (right side). Don't request your master!
- [ ] Make sure you are making a pull request against the develop branch (left side). Also you should start your branch off our develop.
- [ ] Check the commit's or even all commits' message styles matches our requested structure.
- [ ] Check your code additions will fail neither code linting checks nor unit test.



## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?

Menus should include proper roles:

role="menu" for the container.
role="menuitem" for each item.
aria-haspopup="true" and aria-expanded="true" for sub-menus.
aria-label or aria-labelledby for grouped menus or titles.


Shortcuts and assistive text
For command menus, keyboard shortcuts should be included in the visual label (e.g., ⌘ + X) and announced to screen readers if possible.

Use semantic titles for grouped sections to clarify context.
Issue Number: DS-187 


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

-
-
-

## Does this introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
