### PR TITLE
feat: [DS-259-update_footer_logos] Enable prop to add extra logos in the footer 

### DIFF
--- a/src/components/Navigation/Footer/Footer.stories.tsx
+++ b/src/components/Navigation/Footer/Footer.stories.tsx
@@ -118,3 +118,41 @@ export const MaxWidth: Story = {
     ),
   },
 }
+
+export const WithAdditionalLogos: Story = {
+  args: {
+    maxWidth: 1440,
+    filled: true,
+    fixed: true,
+    additionalLogos: [
+      <img
+        src='https://placehold.co/91x32/0066CC/FFFFFF?text=Partner+1'
+        alt='Partner Logo 1'
+        height='32px'
+      />,
+      <img
+        src='https://placehold.co/91x32/00A86B/FFFFFF?text=Partner+2'
+        alt='Partner Logo 2'
+        height='32px'
+      />,
+    ],
+    children: (
+      <>
+        <a
+          href='https://www.wri.org/about/privacy-policy'
+          target='_blank'
+          rel='noreferrer'
+        >
+          Privacy policy
+        </a>
+        <a
+          href='https://www.wri.org/about/wri-data-platforms-tos'
+          target='_blank'
+          rel='noreferrer'
+        >
+          Terms of service
+        </a>
+      </>
+    ),
+  },
+}

--- a/src/components/Navigation/Footer/FooterDemo.tsx
+++ b/src/components/Navigation/Footer/FooterDemo.tsx
@@ -7,15 +7,10 @@ const FooterDemo = () => (
     fixed
     additionalLogos={[
       <img
-        src='https://placehold.co/91x32/0066CC/FFFFFF?text=Partner+1'
-        alt='Partner Logo 1'
+        src='https://placehold.co/91x32/b0b0b0/31343C?font=playfair-display&text=Partner+Logo'
+        alt='Partner Logo'
         height='32px'
-      />,
-      <img
-        src='https://placehold.co/91x32/00A86B/FFFFFF?text=Partner+2'
-        alt='Partner Logo 2'
-        height='32px'
-      />,
+      />
     ]}
   >
     <a

--- a/src/components/Navigation/Footer/FooterDemo.tsx
+++ b/src/components/Navigation/Footer/FooterDemo.tsx
@@ -1,7 +1,23 @@
 import { Footer } from '../..'
 
 const FooterDemo = () => (
-  <Footer maxWidth={1440} filled fixed>
+  <Footer
+    maxWidth={1440}
+    filled
+    fixed
+    additionalLogos={[
+      <img
+        src='https://placehold.co/91x32/0066CC/FFFFFF?text=Partner+1'
+        alt='Partner Logo 1'
+        height='32px'
+      />,
+      <img
+        src='https://placehold.co/91x32/00A86B/FFFFFF?text=Partner+2'
+        alt='Partner Logo 2'
+        height='32px'
+      />,
+    ]}
+  >
     <a
       href='https://www.wri.org/about/privacy-policy'
       target='_blank'

--- a/src/components/Navigation/Footer/README.md
+++ b/src/components/Navigation/Footer/README.md
@@ -40,6 +40,7 @@ type FooterProps = {
   fixed?: boolean
   filled?: boolean
   maxWidth?: number
+  additionalLogos?: React.ReactNode[]
 }
 ```
 
@@ -110,6 +111,35 @@ type FooterProps = {
 
 ```tsx
 <Footer maxWidth={1440}>
+  <a
+    href='https://www.wri.org/about/privacy-policy'
+    target='_blank'
+    rel='noreferrer'
+  >
+    Privacy policy
+  </a>
+  <a
+    href='https://www.wri.org/about/wri-data-platforms-tos'
+    target='_blank'
+    rel='noreferrer'
+  >
+    Terms of service
+  </a>
+</Footer>
+```
+
+## With Additional Logos
+
+```tsx
+<Footer
+  maxWidth={1440}
+  filled
+  fixed
+  additionalLogos={[
+    <img src='/partner-logo-1.svg' alt='Partner Logo 1' height='32px' />,
+    <img src='/partner-logo-2.svg' alt='Partner Logo 2' height='32px' />,
+  ]}
+>
   <a
     href='https://www.wri.org/about/privacy-policy'
     target='_blank'

--- a/src/components/Navigation/Footer/index.tsx
+++ b/src/components/Navigation/Footer/index.tsx
@@ -7,6 +7,7 @@ import {
   footerContentStyles,
   footerLabelStyles,
   footerStyles,
+  footerLogosContainerStyles,
 } from './styled'
 import { WriLogoBlackAndWhiteIcon } from '../../icons'
 
@@ -16,14 +17,16 @@ const Footer = ({
   fixed,
   filled,
   maxWidth,
+  logos,
 }: FooterProps) => {
   const actualYear = new Date().getFullYear()
 
   return (
     <footer css={footerStyles(fixed, filled)}>
       <div css={footerContainerStyles(maxWidth)}>
-        <div>
+        <div css={footerLogosContainerStyles}>
           <WriLogoBlackAndWhiteIcon height='32px' width='91px' />
+          {logos && logos.map((logo, index) => <div key={index}>{logo}</div>)}
         </div>
         <div css={footerContentStyles}>{children}</div>
         <div>

--- a/src/components/Navigation/Footer/index.tsx
+++ b/src/components/Navigation/Footer/index.tsx
@@ -17,7 +17,7 @@ const Footer = ({
   fixed,
   filled,
   maxWidth,
-  logos,
+  additionalLogos,
 }: FooterProps) => {
   const actualYear = new Date().getFullYear()
 
@@ -26,7 +26,8 @@ const Footer = ({
       <div css={footerContainerStyles(maxWidth)}>
         <div css={footerLogosContainerStyles}>
           <WriLogoBlackAndWhiteIcon height='32px' width='91px' />
-          {logos && logos.map((logo, index) => <div key={index}>{logo}</div>)}
+          {/* eslint-disable-next-line react/no-array-index-key */}
+          {additionalLogos && additionalLogos.map((logo, index) => <div key={index}>{logo}</div>)}
         </div>
         <div css={footerContentStyles}>{children}</div>
         <div>

--- a/src/components/Navigation/Footer/styled.ts
+++ b/src/components/Navigation/Footer/styled.ts
@@ -62,3 +62,9 @@ export const footerLabelStyles = css`
     text-align: left;
   }
 `
+
+export const footerLogosContainerStyles = css`
+  display: flex;
+  align-items: center;
+  gap: 16px;
+`

--- a/src/components/Navigation/Footer/types.ts
+++ b/src/components/Navigation/Footer/types.ts
@@ -4,5 +4,5 @@ export type FooterProps = {
   fixed?: boolean
   filled?: boolean
   maxWidth?: number
-  logos?: React.ReactNode[]
+  additionalLogos?: React.ReactNode[]
 }

--- a/src/components/Navigation/Footer/types.ts
+++ b/src/components/Navigation/Footer/types.ts
@@ -4,4 +4,5 @@ export type FooterProps = {
   fixed?: boolean
   filled?: boolean
   maxWidth?: number
+  logos?: React.ReactNode[]
 }


### PR DESCRIPTION
<img width="1624" height="1013" alt="Screenshot 2026-02-02 at 15 30 15" src="https://github.com/user-attachments/assets/85ef616b-a797-465e-bba5-67af44086abe" />

<img width="369" height="259" alt="Screenshot 2026-02-02 at 15 42 28" src="https://github.com/user-attachments/assets/7d3e24a1-0e0e-4cf2-874b-f3c956f72425" />


<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Make sure you are requesting to pull a topic/feature/bugfix branch (right side). Don't request your master!
- [ ] Make sure you are making a pull request against the develop branch (left side). Also you should start your branch off our develop.
- [ ] Check the commit's or even all commits' message styles matches our requested structure.
- [ ] Check your code additions will fail neither code linting checks nor unit test.

## Pull request type

Please check the type of change your PR introduces:
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 

## What is the current behavior?

Issue Number: #259

The Footer component currently renders only the WRI logo. This limits usage for collaborative projects, partnerships, and internal initiatives that need to display multiple organizational logos together for co-branding purposes.

## What is the new behavior?

- Added `additionalLogos` prop to Footer component accepting an array of React nodes
- WRI logo remains the default and primary logo, always rendered first on the left
- Additional logos render horizontally to the right of the WRI logo with consistent 16px spacing
- All logos maintain left-side alignment within the footer layout using the existing space-between logic
- Created new `footerLogosContainerStyles` providing flex layout with proper alignment and gap
- Updated FooterDemo.tsx to showcase the feature with sample partner logo placeholders
- Added `WithAdditionalLogos` story to Footer.stories.tsx demonstrating the new prop
- Updated Footer README.md with prop definition and usage example
- Added eslint-disable comment for array index key usage (acceptable for static logo arrays)

This enhancement enables co-branding capabilities for internal projects and partnerships while preserving all existing footer functionality and responsive behavior.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

The `additionalLogos` prop is optional and fully backward compatible. Existing implementations will continue working without any modifications.

## Other information

**Files Modified:**
- `src/components/Navigation/Footer/types.ts` - Added `additionalLogos?: React.ReactNode[]` to FooterProps interface
- `src/components/Navigation/Footer/index.tsx` - Implemented logo rendering logic
- `src/components/Navigation/Footer/styled.ts` - Added `footerLogosContainerStyles` for layout
- `src/components/Navigation/Footer/FooterDemo.tsx` - Added demo with sample partner logos
- `src/components/Navigation/Footer/Footer.stories.tsx` - Added `WithAdditionalLogos` story
- `src/components/Navigation/Footer/README.md` - Updated documentation with new prop and example

**Visual Testing:**
- Run `npm start` to see the Footer with additional logos in the development environment
- View Storybook story: `Navigation/Footer/WithAdditionalLogos`

**Usage Example:**
```tsx
<Footer
  additionalLogos={[
    <img src='/partner-logo-1.svg' alt='Partner 1' height='32px' />,
    <img src='/partner-logo-2.svg' alt='Partner 2' height='32px' />,
  ]}
>
  {/* footer content */}
</Footer>
```



Notes: 
- Closes [DS-259](https://gfw.atlassian.net/browse/DS-259)

[DS-259]: https://gfw.atlassian.net/browse/DS-259?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ