### PR TITLE
DS-264 - fullwidth size inline message

### DIFF
--- a/src/components/Status/InlineMessage/InlineMessage.stories.tsx
+++ b/src/components/Status/InlineMessage/InlineMessage.stories.tsx
@@ -36,6 +36,17 @@ export const InfoGrey: Story = {
   },
 }
 
+export const FullWidth: Story = {
+  args: {
+    label: 'Full Width',
+    caption:
+      'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent ultrices, nisi vel congue imperdiet, risus felis iaculis metus, sit amet accumsan justo nibh eu odio. Fusce velit augue, bibendum vestibulum elit vel, placerat iaculis dolor. Aliquam tincidunt nunc blandit, consequat magna ut, mollis mi. Morbi ac dictum nisi. Quisque leo neque, vehicula eu lorem ac, convallis pellentesque sem. Proin commodo libero quis nulla tristique, a vehicula sem consectetur. Donec id luctus orci.',
+    variant: 'info-grey',
+    actionLabel: 'Label',
+    size: 'full-width',
+  },
+}
+
 export const Success: Story = {
   args: {
     label: 'Success',

--- a/src/components/Status/InlineMessage/InlineMessageDemo.tsx
+++ b/src/components/Status/InlineMessage/InlineMessageDemo.tsx
@@ -18,6 +18,13 @@ const InlineMessageDemo = () => (
         actionLabel='Label'
       />
       <InlineMessage
+        label='Full width'
+        caption='Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent ultrices, nisi vel congue imperdiet, risus felis iaculis metus, sit amet accumsan justo nibh eu odio. Fusce velit augue, bibendum vestibulum elit vel, placerat iaculis dolor. Aliquam tincidunt nunc blandit, consequat magna ut, mollis mi. Morbi ac dictum nisi. Quisque leo neque, vehicula eu lorem ac, convallis pellentesque sem. Proin commodo libero quis nulla tristique, a vehicula sem consectetur. Donec id luctus orci.'
+        variant='info-white'
+        actionLabel='Label'
+        size='full-width'
+      />
+      <InlineMessage
         label='Label'
         caption='caption'
         variant='info-white'

--- a/src/components/Status/InlineMessage/styled.ts
+++ b/src/components/Status/InlineMessage/styled.ts
@@ -4,22 +4,31 @@ import { getThemedColor } from '../../../lib/theme'
 export const defaultInlineMessageStyles = (
   size: string,
   isButtonRight?: boolean,
-) => css`
-  width: 100%;
-  max-width: ${size === 'small' ? '234px' : '320px'};
-  border-radius: 4px;
-  padding: ${size === 'small' ? '8px 8px 12px 8px' : '8px 12px 12px 12px'};
-  display: flex;
-  align-items: ${isButtonRight ? 'center' : 'flex-start'};
-  justify-content: ${isButtonRight ? 'space-between' : 'flex-start'};
-  flex-direction: ${isButtonRight ? 'row' : 'column'};
-  gap: 8px;
-  margin-bottom: 16px;
-
-  button {
-    margin-left: ${isButtonRight ? 0 : '24px'};
+) => {
+  let maxWidth = '234px'
+  if (size === 'full-width') {
+    maxWidth = '100%'
+  } else if (size === 'large') {
+    maxWidth = '320px'
   }
-`
+
+  return css`
+    width: 100%;
+    max-width: ${maxWidth};
+    border-radius: 4px;
+    padding: ${size === 'small' ? '8px 8px 12px 8px' : '8px 12px 12px 12px'};
+    display: flex;
+    align-items: ${isButtonRight ? 'center' : 'flex-start'};
+    justify-content: ${isButtonRight ? 'space-between' : 'flex-start'};
+    flex-direction: ${isButtonRight ? 'row' : 'column'};
+    gap: 8px;
+    margin-bottom: 16px;
+
+    button {
+      margin-left: ${isButtonRight ? 0 : '24px'};
+    }
+  `
+}
 
 export const inlineMessageHeaderStyles = css`
   display: flex;
@@ -32,6 +41,7 @@ export const inlineMessageHeaderStyles = css`
 `
 
 export const inlineMessageTitleStyles = (size: string) => css`
+  max-width: 720px;
   color: ${getThemedColor('neutral', 800)};
   font-size: ${size === 'small' ? '14px' : '18px'};
   line-height: ${size === 'small' ? '20px' : '28px'};
@@ -40,6 +50,7 @@ export const inlineMessageTitleStyles = (size: string) => css`
 `
 
 export const inlineMessageCaptionStyles = (size: string) => css`
+  max-width: 720px;
   color: ${getThemedColor('neutral', 700)};
   font-size: ${size === 'small' ? '12px' : '16px'};
   line-height: ${size === 'small' ? '16px' : '24px'};

--- a/src/components/Status/InlineMessage/types.ts
+++ b/src/components/Status/InlineMessage/types.ts
@@ -2,7 +2,7 @@ export type InlineMessageProps = {
   label: string
   caption?: string
   variant: 'info-white' | 'info-grey' | 'success' | 'warning' | 'error'
-  size?: 'small' | 'large'
+  size?: 'small' | 'large' | 'full-width'
   icon?: React.ReactNode
   onActionClick?: VoidFunction
   actionLabel?: string


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Make sure you are requesting to pull a topic/feature/bugfix branch (right side). Don't request your master!
- [ ] Make sure you are making a pull request against the develop branch (left side). Also you should start your branch off our develop.
- [ ] Check the commit's or even all commits' message styles matches our requested structure.
- [ ] Check your code additions will fail neither code linting checks nor unit test.



## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?
adds full width-size option for InlineMessage
<img width="1704" height="618" alt="Screenshot 2026-02-12 at 5 06 15 p m" src="https://github.com/user-attachments/assets/619143e7-fabf-4b7d-a067-c08d9870dbd8" />


<!-- Please describe the behavior or changes that are being added by this PR. -->

-
-
-

## Does this introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
