### PR TITLE
[DS-282] update units from px to rem in Navigation components

### DIFF
--- a/src/components/Navigation/Breadcrumb/BreadcrumbDemo.tsx
+++ b/src/components/Navigation/Breadcrumb/BreadcrumbDemo.tsx
@@ -16,29 +16,29 @@ const BreadcrumbDemo = () => {
   return (
     <DemoWrapper title='Breadcrumb'>
       <div>
-        <Link style={{ marginRight: '10px' }} to='/'>
+        <Link style={{ marginRight: '0.625rem' }} to='/'>
           HOME
         </Link>
-        <Link style={{ marginRight: '10px' }} to='/page1'>
+        <Link style={{ marginRight: '0.625rem' }} to='/page1'>
           PAGE1
         </Link>
-        <Link style={{ marginRight: '10px' }} to='/page1/page2'>
+        <Link style={{ marginRight: '0.625rem' }} to='/page1/page2'>
           PAGE2
         </Link>
-        <Link style={{ marginRight: '10px' }} to='/page1/page2/page3'>
+        <Link style={{ marginRight: '0.625rem' }} to='/page1/page2/page3'>
           PAGE3
         </Link>
-        <Link style={{ marginRight: '10px' }} to='/page1/page2/page3/page4'>
+        <Link style={{ marginRight: '0.625rem' }} to='/page1/page2/page3/page4'>
           PAGE4
         </Link>
         <Link
-          style={{ marginRight: '10px' }}
+          style={{ marginRight: '0.625rem' }}
           to='/page1/page2/page3/page4/page5'
         >
           PAGE5
         </Link>
         <Link
-          style={{ marginRight: '10px' }}
+          style={{ marginRight: '0.625rem' }}
           to='/page1/page2/page3/page4/page5/page6'
         >
           PAGE6

--- a/src/components/Navigation/Breadcrumb/index.tsx
+++ b/src/components/Navigation/Breadcrumb/index.tsx
@@ -29,7 +29,7 @@ const Breadcrumb = ({
 
   return (
     <ChakraBreadcrumb.Root>
-      <ChakraBreadcrumb.List gap={size === 'small' ? '6px' : '10px'}>
+      <ChakraBreadcrumb.List gap={size === 'small' ? '0.375rem' : '0.625rem'}>
         {showEllipsis ? (
           <>
             <ChakraBreadcrumb.Item css={breadcrumbItemStyles(size)}>

--- a/src/components/Navigation/Breadcrumb/styled.ts
+++ b/src/components/Navigation/Breadcrumb/styled.ts
@@ -5,19 +5,19 @@ import { BreadcrumbProps } from './types'
 export const breadcrumbItemStyles = (size: BreadcrumbProps['size']) => css`
   a,
   p {
-    font-size: ${size === 'small' ? '12px' : '16px'};
+    font-size: ${size === 'small' ? '0.75rem' : '1rem'};
     font-weight: 400;
-    line-height: ${size === 'small' ? '16px' : '24px'};
+    line-height: ${size === 'small' ? '1rem' : '1.5rem'};
     color: ${getThemedColor('neutral', 600)};
     display: flex;
     align-items: center;
     justify-content: center;
-    gap: 5px;
+    gap: 0.3125rem;
     text-transform: capitalize;
 
     svg {
-      height: ${size === 'small' ? '12px' : '16px'};
-      width: ${size === 'small' ? '12px' : '16px'};
+      height: ${size === 'small' ? '0.75rem' : '1rem'};
+      width: ${size === 'small' ? '0.75rem' : '1rem'};
       color: ${getThemedColor('neutral', 600)};
     }
   }
@@ -38,8 +38,8 @@ export const breadcrumbItemStyles = (size: BreadcrumbProps['size']) => css`
 
 export const breadcrumbSeparatorStyles = (size: BreadcrumbProps['size']) => css`
   svg {
-    height: ${size === 'small' ? '8px' : '12px'};
-    width: ${size === 'small' ? '8px' : '12px'};
+    height: ${size === 'small' ? '0.5rem' : '0.75rem'};
+    width: ${size === 'small' ? '0.5rem' : '0.75rem'};
     color: ${getThemedColor('neutral', 600)};
   }
 `

--- a/src/components/Navigation/Footer/Footer.stories.tsx
+++ b/src/components/Navigation/Footer/Footer.stories.tsx
@@ -95,7 +95,7 @@ export const Fixed: Story = {
 
 export const MaxWidth: Story = {
   args: {
-    maxWidth: 1024,
+    maxWidth: 256,
     filled: true,
     fixed: true,
     children: (
@@ -121,19 +121,19 @@ export const MaxWidth: Story = {
 
 export const WithAdditionalLogos: Story = {
   args: {
-    maxWidth: 1440,
+    maxWidth: 360,
     filled: true,
     fixed: true,
     additionalLogos: [
       <img
         src='https://placehold.co/91x32/0066CC/FFFFFF?text=Partner+1'
         alt='Partner Logo 1'
-        height='32px'
+        height='2rem'
       />,
       <img
         src='https://placehold.co/91x32/00A86B/FFFFFF?text=Partner+2'
         alt='Partner Logo 2'
-        height='32px'
+        height='2rem'
       />,
     ],
     children: (

--- a/src/components/Navigation/Footer/FooterDemo.tsx
+++ b/src/components/Navigation/Footer/FooterDemo.tsx
@@ -2,14 +2,14 @@ import { Footer } from '../..'
 
 const FooterDemo = () => (
   <Footer
-    maxWidth={1440}
+    maxWidth={360}
     filled
     fixed
     additionalLogos={[
       <img
         src='https://placehold.co/91x32/b0b0b0/31343C?font=playfair-display&text=Partner+Logo'
         alt='Partner Logo'
-        height='32px'
+        height='2rem'
       />,
     ]}
   >

--- a/src/components/Navigation/Footer/index.tsx
+++ b/src/components/Navigation/Footer/index.tsx
@@ -25,7 +25,7 @@ const Footer = ({
     <footer css={footerStyles(fixed, filled)}>
       <div css={footerContainerStyles(maxWidth)}>
         <div css={footerLogosContainerStyles}>
-          <WriLogoBlackAndWhiteIcon height='32px' width='91px' />
+          <WriLogoBlackAndWhiteIcon height='2rem' width='5.6875rem' />
           {additionalLogos &&
             // eslint-disable-next-line react/no-array-index-key
             additionalLogos.map((logo, index) => <div key={index}>{logo}</div>)}

--- a/src/components/Navigation/Footer/styled.ts
+++ b/src/components/Navigation/Footer/styled.ts
@@ -1,18 +1,19 @@
 import { css } from '@emotion/react'
 import { getThemedColor } from '../../../lib/theme'
+import { sizeValueToCss } from '../../../lib/sizing'
 import { FooterProps } from './types'
 
 export const footerStyles = (
   fixed?: FooterProps['fixed'],
   filled?: FooterProps['filled'],
 ) => css`
-  min-height: 56px;
+  min-height: 3.5rem;
   width: 100vw;
   position: ${fixed ? 'sticky' : 'absolute'};
   bottom: 0;
   left: 0;
   background-color: ${filled ? getThemedColor('neutral', 200) : 'transparent'};
-  border-top: 1px solid ${getThemedColor('neutral', 400)};
+  border-top: 0.0625rem solid ${getThemedColor('neutral', 400)};
   z-index: 101;
 `
 
@@ -21,15 +22,15 @@ export const footerContainerStyles = (
 ) => css`
   height: 100%;
   width: 100%;
-  max-width: ${maxWidth ? `${maxWidth}px` : '100%'};
+  max-width: ${maxWidth != null ? sizeValueToCss(maxWidth) : '100%'};
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: 32px;
-  padding: 12px 16px;
+  gap: 2rem;
+  padding: 0.75rem 1rem;
   margin: 0 auto;
 
-  @media screen and (max-width: 768px) {
+  @media screen and (max-width: 48rem) {
     flex-direction: column;
     align-items: flex-start;
   }
@@ -39,11 +40,11 @@ export const footerContentStyles = css`
   display: flex;
   align-items: center;
   flex-wrap: wrap;
-  gap: 24px;
+  gap: 1.5rem;
 
   a {
-    font-size: 14px;
-    line-height: 20px;
+    font-size: 0.875rem;
+    line-height: 1.25rem;
     font-weight: 400;
     color: ${getThemedColor('neutral', 700)};
     text-decoration: underline;
@@ -51,14 +52,14 @@ export const footerContentStyles = css`
 `
 
 export const footerLabelStyles = css`
-  width: 240px;
-  font-size: 14px;
-  line-height: 20px;
+  width: 15rem;
+  font-size: 0.875rem;
+  line-height: 1.25rem;
   font-weight: 400;
   color: ${getThemedColor('neutral', 600)};
   text-align: right;
 
-  @media screen and (max-width: 768px) {
+  @media screen and (max-width: 48rem) {
     text-align: left;
   }
 `
@@ -66,5 +67,5 @@ export const footerLabelStyles = css`
 export const footerLogosContainerStyles = css`
   display: flex;
   align-items: center;
-  gap: 16px;
+  gap: 1rem;
 `

--- a/src/components/Navigation/Footer/styled.ts
+++ b/src/components/Navigation/Footer/styled.ts
@@ -1,6 +1,6 @@
 import { css } from '@emotion/react'
 import { getThemedColor } from '../../../lib/theme'
-import { sizeValueToCss } from '../../../lib/sizing'
+import { resolveSizeValue } from '../../../lib/sizing'
 import { FooterProps } from './types'
 
 export const footerStyles = (
@@ -22,7 +22,7 @@ export const footerContainerStyles = (
 ) => css`
   height: 100%;
   width: 100%;
-  max-width: ${maxWidth != null ? sizeValueToCss(maxWidth) : '100%'};
+  max-width: ${maxWidth != null ? resolveSizeValue(maxWidth) : '100%'};
   display: flex;
   align-items: center;
   justify-content: space-between;

--- a/src/components/Navigation/Footer/types.ts
+++ b/src/components/Navigation/Footer/types.ts
@@ -1,8 +1,10 @@
+import type { SizeValue } from '../../../lib/sizing'
+
 export type FooterProps = {
   children: React.ReactNode
   label?: string
   fixed?: boolean
   filled?: boolean
-  maxWidth?: number
+  maxWidth?: SizeValue
   additionalLogos?: React.ReactNode[]
 }

--- a/src/components/Navigation/MobileTabBar/MobileTabBar.stories.tsx
+++ b/src/components/Navigation/MobileTabBar/MobileTabBar.stories.tsx
@@ -14,7 +14,7 @@ const meta = {
   tags: ['autodocs'],
   decorators: [
     (Story: any) => (
-      <div style={{ width: '320px' }}>
+      <div style={{ width: '20rem' }}>
         <Story />
       </div>
     ),

--- a/src/components/Navigation/MobileTabBar/MobileTabBarDemo.tsx
+++ b/src/components/Navigation/MobileTabBar/MobileTabBarDemo.tsx
@@ -31,8 +31,12 @@ const MobileTabBarDemo = () => (
         onTabClick={console.log}
       />
     </div>
-    <div style={{ width: '100%', maxWidth: '28.125rem', margin: '1.5625rem 0' }}>
-      <p style={{ marginBottom: '0.625rem', fontWeight: 'bold' }}>Default Active</p>
+    <div
+      style={{ width: '100%', maxWidth: '28.125rem', margin: '1.5625rem 0' }}
+    >
+      <p style={{ marginBottom: '0.625rem', fontWeight: 'bold' }}>
+        Default Active
+      </p>
       <MobileTabBar
         tabs={[
           { label: 'One', value: 'one', icon: <PlaceholderIcon /> },
@@ -58,7 +62,9 @@ const MobileTabBarDemo = () => (
         defaultValue='two'
       />
     </div>
-    <div style={{ width: '100%', maxWidth: '28.125rem', margin: '1.5625rem 0' }}>
+    <div
+      style={{ width: '100%', maxWidth: '28.125rem', margin: '1.5625rem 0' }}
+    >
       <p style={{ marginBottom: '0.625rem', fontWeight: 'bold' }}>Disabled</p>
       <MobileTabBar
         tabs={[
@@ -85,7 +91,9 @@ const MobileTabBarDemo = () => (
         onTabClick={console.log}
       />
     </div>
-    <div style={{ width: '100%', maxWidth: '28.125rem', margin: '1.5625rem 0' }}>
+    <div
+      style={{ width: '100%', maxWidth: '28.125rem', margin: '1.5625rem 0' }}
+    >
       <p style={{ marginBottom: '0.625rem', fontWeight: 'bold' }}>
         With Hidden Labels
       </p>
@@ -114,7 +122,9 @@ const MobileTabBarDemo = () => (
         hideLabels
       />
     </div>
-    <div style={{ width: '100%', maxWidth: '28.125rem', margin: '1.5625rem 0' }}>
+    <div
+      style={{ width: '100%', maxWidth: '28.125rem', margin: '1.5625rem 0' }}
+    >
       <p style={{ marginBottom: '0.625rem', fontWeight: 'bold' }}>
         Automatic activation mode
       </p>

--- a/src/components/Navigation/MobileTabBar/MobileTabBarDemo.tsx
+++ b/src/components/Navigation/MobileTabBar/MobileTabBarDemo.tsx
@@ -6,7 +6,7 @@ import DemoWrapper from '../../UI/DemoWrapper'
 
 const MobileTabBarDemo = () => (
   <DemoWrapper title='Mobile Tab Bar'>
-    <div style={{ width: '100%', maxWidth: '450px' }}>
+    <div style={{ width: '100%', maxWidth: '28.125rem' }}>
       <MobileTabBar
         tabs={[
           { label: 'One', value: 'one', icon: <PlaceholderIcon /> },
@@ -31,8 +31,8 @@ const MobileTabBarDemo = () => (
         onTabClick={console.log}
       />
     </div>
-    <div style={{ width: '100%', maxWidth: '450px', margin: '25px 0' }}>
-      <p style={{ marginBottom: '10px', fontWeight: 'bold' }}>Default Active</p>
+    <div style={{ width: '100%', maxWidth: '28.125rem', margin: '1.5625rem 0' }}>
+      <p style={{ marginBottom: '0.625rem', fontWeight: 'bold' }}>Default Active</p>
       <MobileTabBar
         tabs={[
           { label: 'One', value: 'one', icon: <PlaceholderIcon /> },
@@ -58,8 +58,8 @@ const MobileTabBarDemo = () => (
         defaultValue='two'
       />
     </div>
-    <div style={{ width: '100%', maxWidth: '450px', margin: '25px 0' }}>
-      <p style={{ marginBottom: '10px', fontWeight: 'bold' }}>Disabled</p>
+    <div style={{ width: '100%', maxWidth: '28.125rem', margin: '1.5625rem 0' }}>
+      <p style={{ marginBottom: '0.625rem', fontWeight: 'bold' }}>Disabled</p>
       <MobileTabBar
         tabs={[
           { label: 'One', value: 'one', icon: <PlaceholderIcon /> },
@@ -85,8 +85,8 @@ const MobileTabBarDemo = () => (
         onTabClick={console.log}
       />
     </div>
-    <div style={{ width: '100%', maxWidth: '450px', margin: '25px 0' }}>
-      <p style={{ marginBottom: '10px', fontWeight: 'bold' }}>
+    <div style={{ width: '100%', maxWidth: '28.125rem', margin: '1.5625rem 0' }}>
+      <p style={{ marginBottom: '0.625rem', fontWeight: 'bold' }}>
         With Hidden Labels
       </p>
       <MobileTabBar
@@ -114,8 +114,8 @@ const MobileTabBarDemo = () => (
         hideLabels
       />
     </div>
-    <div style={{ width: '100%', maxWidth: '450px', margin: '25px 0' }}>
-      <p style={{ marginBottom: '10px', fontWeight: 'bold' }}>
+    <div style={{ width: '100%', maxWidth: '28.125rem', margin: '1.5625rem 0' }}>
+      <p style={{ marginBottom: '0.625rem', fontWeight: 'bold' }}>
         Automatic activation mode
       </p>
       <MobileTabBar

--- a/src/components/Navigation/MobileTabBar/styled.ts
+++ b/src/components/Navigation/MobileTabBar/styled.ts
@@ -5,30 +5,30 @@ export const mobileTabBarContainerStyles = css`
   width: 100%;
   display: flex;
   align-items: center;
-  height: 56px;
+  height: 3.5rem;
   background-color: ${getThemedColor('neutral', 200)};
 `
 
 export const mobileTabBarItemStyles = css`
-  height: 56px;
+  height: 3.5rem;
   width: 99%;
   background-color: ${getThemedColor('neutral', 200)};
   color: ${getThemedColor('neutral', 700)};
-  padding: 10px 4px 8px 4px;
-  border-radius: 0px;
+  padding: 0.625rem 0.25rem 0.5rem 0.25rem;
+  border-radius: 0rem;
   display: flex;
   justify-content: flex-start;
   align-items: center;
   flex-direction: column;
-  gap: 6px;
-  font-size: 10px;
-  line-height: 14px;
+  gap: 0.375rem;
+  font-size: 0.625rem;
+  line-height: 0.875rem;
   font-weight: 400;
-  border-bottom: 2px solid transparent;
+  border-bottom: 0.125rem solid transparent;
 
   svg {
-    height: 16px;
-    width: 16px;
+    height: 1rem;
+    width: 1rem;
 
     path {
       fill: ${getThemedColor('neutral', 600)};
@@ -46,17 +46,17 @@ export const mobileTabBarItemStyles = css`
   &:focus-visible {
     background-color: ${getThemedColor('neutral', 300)};
     outline-color: ${getThemedColor('primary', 700)};
-    outline-offset: 2px;
+    outline-offset: 0.125rem;
     box-shadow:
-      0 0 0 2px ${getThemedColor('neutral', 100)},
-      rgba(0, 0, 0, 0.05) 0px 2px 2px 4px;
+      0 0 0 0.125rem ${getThemedColor('neutral', 100)},
+      rgba(0, 0, 0, 0.05) 0rem 0.125rem 0.125rem 0.25rem;
   }
 
   &[data-selected] {
     background-color: ${getThemedColor('neutral', 100)};
     color: ${getThemedColor('neutral', 800)};
     font-weight: 700;
-    border-bottom: 2px solid ${getThemedColor('primary', 500)};
+    border-bottom: 0.125rem solid ${getThemedColor('primary', 500)};
 
     svg path {
       fill: ${getThemedColor('neutral', 700)};
@@ -73,10 +73,10 @@ export const mobileTabBarItemStyles = css`
     &:focus-visible {
       background-color: ${getThemedColor('neutral', 100)};
       outline-color: ${getThemedColor('primary', 700)};
-      outline-offset: 2px;
+      outline-offset: 0.125rem;
       box-shadow:
-        0 0 0 2px ${getThemedColor('neutral', 100)},
-        rgba(0, 0, 0, 0.05) 0px 2px 2px 4px;
+        0 0 0 0.125rem ${getThemedColor('neutral', 100)},
+        rgba(0, 0, 0, 0.05) 0rem 0.125rem 0.125rem 0.25rem;
     }
 
     &::before {
@@ -87,7 +87,7 @@ export const mobileTabBarItemStyles = css`
   &[data-disabled] {
     background-color: ${getThemedColor('neutral', 200)};
     color: ${getThemedColor('neutral', 400)};
-    border-bottom: 2px solid transparent;
+    border-bottom: 0.125rem solid transparent;
 
     svg path {
       fill: ${getThemedColor('neutral', 400)};
@@ -111,15 +111,15 @@ export const mobileTabBarItemIconContainerStyles = css`
 
 export const mobileTabBarItemBadgeStyles = css`
   position: absolute;
-  top: -5px;
-  right: -5px;
-  height: 12px;
-  width: 12px;
-  border-radius: 6px;
+  top: -0.3125rem;
+  right: -0.3125rem;
+  height: 0.75rem;
+  width: 0.75rem;
+  border-radius: 0.375rem;
   background-color: ${getThemedColor('error', 500)};
   font-weight: 700;
-  font-size: 8px;
-  line-height: 10px;
+  font-size: 0.5rem;
+  line-height: 0.625rem;
   color: ${getThemedColor('neutral', 100)};
   display: flex;
   justify-content: center;

--- a/src/components/Navigation/Navbar/Navbar.stories.tsx
+++ b/src/components/Navigation/Navbar/Navbar.stories.tsx
@@ -33,8 +33,8 @@ const meta = {
       <div
         style={{
           width: '100%',
-          maxWidth: '1440px',
-          height: '300px',
+          maxWidth: '90rem',
+          height: '18.75rem',
           margin: '0 auto',
         }}
       >
@@ -74,8 +74,8 @@ export const Navbar: Story = {
         logo={
           <Link to='/'>
             <WriLogoIcon
-              height={variant === 'condensed' ? '20px' : '32px'}
-              width='92px'
+              height={variant === 'condensed' ? '1.25rem' : '2rem'}
+              width='5.75rem'
             />
           </Link>
         }
@@ -141,11 +141,11 @@ export const Navbar: Story = {
           },
         ]}
         utilitySection={[
-          <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
+          <div style={{ display: 'flex', alignItems: 'center', gap: '0.5rem' }}>
             Notifications
             <Badge notificationCount={3} hasNotification />
           </div>,
-          <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
+          <div style={{ display: 'flex', alignItems: 'center', gap: '0.5rem' }}>
             <Avatar
               name='John Doe'
               src='https://bit.ly/sage-adebayo'
@@ -165,7 +165,7 @@ export const Navbar: Story = {
         actionsSection={[
           { ariaLabel: 'Sign in', children: 'Sign in', onClick: () => {} },
         ]}
-        maxWidth={1440}
+        maxWidth={360}
         fixed
       />
     )
@@ -200,8 +200,8 @@ export const Condensed: Story = {
         logo={
           <Link to='/'>
             <WriLogoIcon
-              height={variant === 'condensed' ? '20px' : '32px'}
-              width='92px'
+              height={variant === 'condensed' ? '1.25rem' : '2rem'}
+              width='5.75rem'
             />
           </Link>
         }
@@ -268,7 +268,7 @@ export const Condensed: Story = {
         ]}
         utilitySection={[]}
         actionsSection={[]}
-        maxWidth={1440}
+        maxWidth={360}
         fixed
       />
     )

--- a/src/components/Navigation/Navbar/NavbarDemo.tsx
+++ b/src/components/Navigation/Navbar/NavbarDemo.tsx
@@ -22,7 +22,7 @@ const NavbarDemo = () => {
     <Navbar
       logo={
         <Link to='/'>
-          <WriLogoIcon height='32px' width='92px' />
+          <WriLogoIcon height='2rem' width='5.75rem' />
         </Link>
       }
       linkRouter={Link}
@@ -87,10 +87,10 @@ const NavbarDemo = () => {
         },
       ]}
       utilitySection={[
-        <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
+        <div style={{ display: 'flex', alignItems: 'center', gap: '0.5rem' }}>
           <Badge label='Notifications' notificationCount={3} />
         </div>,
-        <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
+        <div style={{ display: 'flex', alignItems: 'center', gap: '0.5rem' }}>
           <Avatar
             name='John Doe'
             src='https://bit.ly/sage-adebayo'
@@ -110,7 +110,7 @@ const NavbarDemo = () => {
       actionsSection={[
         { ariaLabel: 'Sign in', children: 'Sign in', onClick: () => {} },
       ]}
-      maxWidth={1440}
+      maxWidth={360}
       fixed
     />
   )

--- a/src/components/Navigation/Navbar/NavbarMobile.tsx
+++ b/src/components/Navigation/Navbar/NavbarMobile.tsx
@@ -56,7 +56,7 @@ const NavbarMobile = ({
                 overflowY: 'scroll',
                 width: '100%',
                 height: '100%',
-                paddingBottom: '72px',
+                paddingBottom: '4.5rem',
               }}
             >
               {utilitySection ? (
@@ -174,7 +174,7 @@ const NavbarMobile = ({
                 css={navbarMenuActionStyles(theme)}
               >
                 {resolvedLabels.closeButtonText}
-                <CloseIcon height='16px' width='16px' />
+                <CloseIcon height='1rem' width='1rem' />
               </button>
             </div>
             <div css={navbarMobileNavigationLinksContainerStyles}>

--- a/src/components/Navigation/Navbar/index.tsx
+++ b/src/components/Navigation/Navbar/index.tsx
@@ -167,7 +167,7 @@ const Navbar = ({
                   theme={theme}
                   key={item.label}
                   label={item.label}
-                  fontSize={isCondensed ? '14px' : '16px'}
+                  fontSize={isCondensed ? '0.875rem' : '1rem'}
                   items={item.items || []}
                 />
               )
@@ -203,13 +203,13 @@ const Navbar = ({
               {isOpen ? l.closeLabel : l.menuLabel}
               {isOpen ? (
                 <CloseIcon
-                  height={isCondensed ? '12px' : '16px'}
-                  width={isCondensed ? '12px' : '16px'}
+                  height={isCondensed ? '0.75rem' : '1rem'}
+                  width={isCondensed ? '0.75rem' : '1rem'}
                 />
               ) : (
                 <MenuIcon
-                  height={isCondensed ? '12px' : '16px'}
-                  width={isCondensed ? '12px' : '16px'}
+                  height={isCondensed ? '0.75rem' : '1rem'}
+                  width={isCondensed ? '0.75rem' : '1rem'}
                 />
               )}
             </button>
@@ -242,7 +242,7 @@ const Navbar = ({
                 theme={theme}
                 key={item.label}
                 label={item.label}
-                fontSize={isCondensed ? '14px' : '16px'}
+                fontSize={isCondensed ? '0.875rem' : '1rem'}
                 items={item.items || []}
               />
             )

--- a/src/components/Navigation/Navbar/styles.ts
+++ b/src/components/Navigation/Navbar/styles.ts
@@ -1,6 +1,6 @@
 import { css } from '@emotion/react'
 import { getThemedColor } from '../../../lib/theme'
-import { sizeValueToCss } from '../../../lib/sizing'
+import { resolveSizeValue } from '../../../lib/sizing'
 import { NavbarProps } from './types'
 
 export const navbarStyles = (
@@ -42,8 +42,8 @@ export const navbarSecondBarStyles = (
     : getThemedColor('neutral', 100)};
   border-bottom: 0.0625rem solid
     ${theme === 'dark'
-      ? getThemedColor('neutral', 800)
-      : getThemedColor('neutral', 400)};
+    ? getThemedColor('neutral', 800)
+    : getThemedColor('neutral', 400)};
   display: flex;
   align-items: center;
   justify-content: flex-start;
@@ -58,7 +58,7 @@ export const navbarContainerStyles = (
 ) => css`
   height: ${isCondensed ? '1.75rem' : '3rem'};
   width: 100%;
-  max-width: ${maxWidth ? sizeValueToCss(maxWidth) : '100%'};
+  max-width: ${maxWidth ? resolveSizeValue(maxWidth) : '100%'};
   background-color: ${isBlack ? getThemedColor('neutral', 800) : 'transparent'};
   display: flex;
   align-items: ${isCondensed ? 'start' : 'center'};
@@ -115,8 +115,8 @@ export const navbarLeftLinkStyles = (
 
   &:hover {
     background-color: ${theme === 'dark'
-      ? 'default'
-      : getThemedColor('neutral', 200)};
+    ? 'default'
+    : getThemedColor('neutral', 200)};
   }
 
   &:focus-visible {
@@ -196,8 +196,8 @@ export const navbarMenuActionStyles = (
 
   &:hover {
     background-color: ${theme === 'dark'
-      ? 'default'
-      : getThemedColor('neutral', 200)};
+    ? 'default'
+    : getThemedColor('neutral', 200)};
   }
 
   &:focus-visible {

--- a/src/components/Navigation/Navbar/styles.ts
+++ b/src/components/Navigation/Navbar/styles.ts
@@ -1,5 +1,6 @@
 import { css } from '@emotion/react'
 import { getThemedColor } from '../../../lib/theme'
+import { sizeValueToCss } from '../../../lib/sizing'
 import { NavbarProps } from './types'
 
 export const navbarStyles = (
@@ -9,11 +10,11 @@ export const navbarStyles = (
   theme?: NavbarProps['theme'],
   isCondensed?: boolean,
 ) => {
-  let maxHeight = '48px'
+  let maxHeight = '3rem'
   if (isFullHeight) {
-    maxHeight = '96px'
+    maxHeight = '6rem'
   } else if (isCondensed) {
-    maxHeight = '28px'
+    maxHeight = '1.75rem'
   }
 
   return css`
@@ -27,27 +28,27 @@ export const navbarStyles = (
     top: 0;
     left: 0;
     z-index: 102;
-    border-bottom: 1px solid ${getThemedColor('neutral', 400)};
+    border-bottom: 0.0625rem solid ${getThemedColor('neutral', 400)};
   `
 }
 export const navbarSecondBarStyles = (
   theme?: NavbarProps['theme'],
   isCondensed?: boolean,
 ) => css`
-  height: ${isCondensed ? '28px' : '48px'};
+  height: ${isCondensed ? '1.75rem' : '3rem'};
   width: 100%;
   background-color: ${theme === 'dark'
     ? getThemedColor('neutral', 800)
     : getThemedColor('neutral', 100)};
-  border-bottom: 1px solid
+  border-bottom: 0.0625rem solid
     ${theme === 'dark'
-      ? getThemedColor('neutral', 800)
-      : getThemedColor('neutral', 400)};
+    ? getThemedColor('neutral', 800)
+    : getThemedColor('neutral', 400)};
   display: flex;
   align-items: center;
   justify-content: flex-start;
-  gap: 0px;
-  padding: ${isCondensed ? '0px' : '8px 16px'};
+  gap: 0rem;
+  padding: ${isCondensed ? '0rem' : '0.5rem 1rem'};
 `
 
 export const navbarContainerStyles = (
@@ -55,16 +56,16 @@ export const navbarContainerStyles = (
   maxWidth?: NavbarProps['maxWidth'],
   isCondensed?: boolean,
 ) => css`
-  height: ${isCondensed ? '28px' : '48px'};
+  height: ${isCondensed ? '1.75rem' : '3rem'};
   width: 100%;
-  max-width: ${maxWidth ? `${maxWidth}px` : '100%'};
+  max-width: ${maxWidth ? sizeValueToCss(maxWidth) : '100%'};
   background-color: ${isBlack ? getThemedColor('neutral', 800) : 'transparent'};
   display: flex;
   align-items: ${isCondensed ? 'start' : 'center'};
 
   justify-content: space-between;
   margin: 0 auto;
-  padding: ${isCondensed ? '0px' : '8px 16px'};
+  padding: ${isCondensed ? '0rem' : '0.5rem 1rem'};
 `
 
 export const navbarLeftContainerStyles = (
@@ -72,9 +73,9 @@ export const navbarLeftContainerStyles = (
   isCondensed: boolean,
 ) => css`
   display: flex;
-  margin: ${isCondensed ? '-1px' : '0px'};
+  margin: ${isCondensed ? '-0.0625rem' : '0rem'};
   justify-content: flex-start;
-  gap: 12px;
+  gap: 0.75rem;
   color: ${getThemedColor('neutral', isBlackBackground ? 100 : 900)};
 `
 
@@ -83,11 +84,11 @@ export const navbarLogoContainerStyles = css`
 
   a {
     &:focus-visible {
-      border-radius: 0px;
+      border-radius: 0rem;
       outline-color: ${getThemedColor('primary', 700)};
-      outline-offset: 4px;
+      outline-offset: 0.25rem;
       outline-style: solid;
-      outline-width: 2px;
+      outline-width: 0.125rem;
     }
   }
 `
@@ -96,7 +97,7 @@ export const navbarLeftItemsContainerStyles = (divsCollided: boolean) => css`
   display: ${divsCollided ? 'none' : 'flex'};
   align-items: center;
   justify-content: flex-start;
-  gap: 0px;
+  gap: 0rem;
 `
 
 export const navbarLeftLinkStyles = (
@@ -104,28 +105,28 @@ export const navbarLeftLinkStyles = (
   theme?: NavbarProps['theme'],
   isCondensed?: boolean,
 ) => css`
-  font-size: ${isCondensed ? '14px' : '16px'};
-  line-height: 24px;
+  font-size: ${isCondensed ? '0.875rem' : '1rem'};
+  line-height: 1.5rem;
   font-weight: 400;
   color: ${theme === 'dark'
     ? getThemedColor('neutral', 200)
     : getThemedColor('neutral', 900)};
-  padding: 2px 12px;
+  padding: 0.125rem 0.75rem;
 
   &:hover {
     background-color: ${theme === 'dark'
-      ? 'default'
-      : getThemedColor('neutral', 200)};
+    ? 'default'
+    : getThemedColor('neutral', 200)};
   }
 
   &:focus-visible {
     box-shadow:
-      0 0 0 2px ${getThemedColor('neutral', 100)},
-      rgba(0, 0, 0, 0.05) 0px 2px 2px 4px;
+      0 0 0 0.125rem ${getThemedColor('neutral', 100)},
+      rgba(0, 0, 0, 0.05) 0rem 0.125rem 0.125rem 0.25rem;
     outline-color: ${getThemedColor('primary', 700)};
-    outline-offset: 2px;
+    outline-offset: 0.125rem;
     outline-style: solid;
-    outline-width: 2px;
+    outline-width: 0.125rem;
   }
 
   ${active
@@ -137,7 +138,7 @@ export const navbarLeftLinkStyles = (
 `
 
 export const navbarRightContainerStyles = (isCondensed?: boolean) => css`
-  height: ${isCondensed ? '28px' : '48px'};
+  height: ${isCondensed ? '1.75rem' : '3rem'};
   display: flex;
   align-items: center;
   justify-content: flex-end;
@@ -145,15 +146,15 @@ export const navbarRightContainerStyles = (isCondensed?: boolean) => css`
 
 export const navbarRightItemStyles = (divsCollided?: boolean) => css`
   height: 100%;
-  font-size: 16px;
-  line-height: 24px;
+  font-size: 1rem;
+  line-height: 1.5rem;
   font-weight: 400;
   color: ${getThemedColor('neutral', divsCollided ? 100 : 900)};
-  border-left: 1px solid ${getThemedColor('neutral', divsCollided ? 700 : 300)};
+  border-left: 0.0625rem solid ${getThemedColor('neutral', divsCollided ? 700 : 300)};
   display: flex;
   align-items: center;
   justify-content: center;
-  padding: 0 12px;
+  padding: 0 0.75rem;
 
   ${divsCollided
     ? css`
@@ -171,9 +172,9 @@ export const navbarActionsContainerStyles = (divsCollided: boolean) => css`
   display: flex;
   align-items: center;
   justify-content: flex-end;
-  gap: 20px;
-  padding-left: 16px;
-  border-left: 1px solid ${getThemedColor('neutral', divsCollided ? 700 : 300)};
+  gap: 1.25rem;
+  padding-left: 1rem;
+  border-left: 0.0625rem solid ${getThemedColor('neutral', divsCollided ? 700 : 300)};
 `
 
 export const navbarMenuActionStyles = (
@@ -183,28 +184,28 @@ export const navbarMenuActionStyles = (
   background-color: none;
   border: none;
   cursor: pointer;
-  padding: 0px;
-  font-size: ${isCondensed ? '14px' : '16px'};
+  padding: 0rem;
+  font-size: ${isCondensed ? '0.875rem' : '1rem'};
   color: ${getThemedColor('neutral', theme === 'dark' ? 100 : 800)};
   display: flex;
   justify-content: center;
   align-items: center;
-  gap: 8px;
+  gap: 0.5rem;
 
   &:hover {
     background-color: ${theme === 'dark'
-      ? 'default'
-      : getThemedColor('neutral', 200)};
+    ? 'default'
+    : getThemedColor('neutral', 200)};
   }
 
   &:focus-visible {
     box-shadow:
-      0 0 0 2px ${getThemedColor('neutral', 100)},
-      rgba(0, 0, 0, 0.05) 0px 2px 2px 4px;
+      0 0 0 0.125rem ${getThemedColor('neutral', 100)},
+      rgba(0, 0, 0, 0.05) 0rem 0.125rem 0.125rem 0.25rem;
     outline-color: ${getThemedColor('primary', 700)};
-    outline-offset: 4px;
+    outline-offset: 0.25rem;
     outline-style: solid;
-    outline-width: 2px;
+    outline-width: 0.125rem;
     background-color: ${getThemedColor('neutral', 200)};
   }
 `
@@ -214,16 +215,16 @@ export const navbarMobileStyles = (
   isCondensed?: boolean,
 ) => css`
   position: absolute;
-  top: ${isCondensed ? '28px' : '48px'};
+  top: ${isCondensed ? '1.75rem' : '3rem'};
   right: 0;
-  height: calc(100vh - ${isCondensed ? '28px' : '48px'});
-  width: ${isOpen ? '100%' : '0px'};
+  height: calc(100vh - ${isCondensed ? '1.75rem' : '3rem'});
+  width: ${isOpen ? '100%' : '0rem'};
   background-color: ${getThemedColor('neutral', 100)};
   display: flex;
   flex-direction: column;
   align-items: flex-start;
   justify-content: flex-start;
-  gap: 16px;
+  gap: 1rem;
   transition: width 0.5s ease-in-out;
 `
 
@@ -238,22 +239,22 @@ export const navbarMobileUtilityContainerStyles = (
   background-color: ${theme === 'dark'
     ? getThemedColor('neutral', 800)
     : getThemedColor('neutral', 200)};
-  border-bottom: 1px solid ${getThemedColor('neutral', 300)};
+  border-bottom: 0.0625rem solid ${getThemedColor('neutral', 300)};
 
   .ds-utility-item {
-    padding: 12px 16px;
+    padding: 0.75rem 1rem;
     width: 100%;
-    height: 48px;
+    height: 3rem;
     display: flex;
     align-items: center;
     justify-content: flex-start;
 
     button {
-      height: 48px;
+      height: 3rem;
       display: flex;
       align-items: center;
       justify-content: flex-start;
-      margin-left: -12px;
+      margin-left: -0.75rem;
     }
   }
 `
@@ -273,7 +274,7 @@ export const navbarMobileNavigationLinkItemContainerStyles = css``
 export const navbarMobileNavigationLinkItemStyles = (active?: boolean) => css`
   display: inline-block;
   width: 100%;
-  padding: 12px 16px;
+  padding: 0.75rem 1rem;
   color: ${getThemedColor('neutral', 900)};
   text-align: left;
   cursor: pointer;
@@ -290,22 +291,22 @@ export const navbarMobileNavigationLinkItemStyles = (active?: boolean) => css`
   }
 
   &:focus-visible {
-    width: calc(100% - 4px);
-    padding: 12px 16px;
+    width: calc(100% - 0.25rem);
+    padding: 0.75rem 1rem;
     box-shadow:
-      0 0 0 2px ${getThemedColor('neutral', 100)},
-      rgba(0, 0, 0, 0.05) 0px 2px 2px 4px;
+      0 0 0 0.125rem ${getThemedColor('neutral', 100)},
+      rgba(0, 0, 0, 0.05) 0rem 0.125rem 0.125rem 0.25rem;
     outline-color: ${getThemedColor('primary', 700)};
-    outline-offset: 2px;
+    outline-offset: 0.125rem;
     outline-style: solid;
-    outline-width: 2px;
+    outline-width: 0.125rem;
     background-color: ${getThemedColor('neutral', 200)};
   }
 `
 
 export const navbarMobileNavigationMenuStyles = css`
   width: 100%;
-  padding: 12px 16px;
+  padding: 0.75rem 1rem;
   display: flex;
   align-items: center;
   justify-content: space-between;
@@ -316,25 +317,25 @@ export const navbarMobileNavigationMenuStyles = css`
   }
 
   &:focus-visible {
-    width: calc(100% - 4px);
-    padding: 12px 16px;
+    width: calc(100% - 0.25rem);
+    padding: 0.75rem 1rem;
     box-shadow:
-      0 0 0 2px ${getThemedColor('neutral', 100)},
-      rgba(0, 0, 0, 0.05) 0px 2px 2px 4px;
+      0 0 0 0.125rem ${getThemedColor('neutral', 100)},
+      rgba(0, 0, 0, 0.05) 0rem 0.125rem 0.125rem 0.25rem;
     outline-color: ${getThemedColor('primary', 700)};
-    outline-offset: 2px;
+    outline-offset: 0.125rem;
     outline-style: solid;
-    outline-width: 2px;
+    outline-width: 0.125rem;
     background-color: ${getThemedColor('neutral', 200)};
   }
 `
 
 export const navbarMobileSubmenuStyles = (isOpen?: boolean) => css`
   position: absolute;
-  top: 0px;
+  top: 0rem;
   right: 0;
   height: 100vh;
-  width: ${isOpen ? '100%' : '0px'};
+  width: ${isOpen ? '100%' : '0rem'};
   background-color: ${getThemedColor('neutral', 100)};
   display: flex;
   flex-direction: column;
@@ -344,13 +345,13 @@ export const navbarMobileSubmenuStyles = (isOpen?: boolean) => css`
 `
 
 export const navbarMobileSubmenuHeaderStyles = css`
-  height: 48px;
+  height: 3rem;
   width: 100%;
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: 16px;
-  border-bottom: 1px solid ${getThemedColor('neutral', 400)};
+  padding: 1rem;
+  border-bottom: 0.0625rem solid ${getThemedColor('neutral', 400)};
   position: relative;
   top: 0;
   left: 0;
@@ -360,15 +361,15 @@ export const navbarMobileActionsContainerStyles = css`
   position: absolute;
   bottom: 0;
   left: 0;
-  height: 72px;
+  height: 4.5rem;
   width: 100%;
   background-color: ${getThemedColor('neutral', 200)};
   display: flex;
   align-items: center;
   justify-content: center;
-  gap: 12px;
+  gap: 0.75rem;
 
   button {
-    width: calc(48% - 24px);
+    width: calc(48% - 1.5rem);
   }
 `

--- a/src/components/Navigation/Navbar/styles.ts
+++ b/src/components/Navigation/Navbar/styles.ts
@@ -42,8 +42,8 @@ export const navbarSecondBarStyles = (
     : getThemedColor('neutral', 100)};
   border-bottom: 0.0625rem solid
     ${theme === 'dark'
-    ? getThemedColor('neutral', 800)
-    : getThemedColor('neutral', 400)};
+      ? getThemedColor('neutral', 800)
+      : getThemedColor('neutral', 400)};
   display: flex;
   align-items: center;
   justify-content: flex-start;
@@ -115,8 +115,8 @@ export const navbarLeftLinkStyles = (
 
   &:hover {
     background-color: ${theme === 'dark'
-    ? 'default'
-    : getThemedColor('neutral', 200)};
+      ? 'default'
+      : getThemedColor('neutral', 200)};
   }
 
   &:focus-visible {
@@ -150,7 +150,8 @@ export const navbarRightItemStyles = (divsCollided?: boolean) => css`
   line-height: 1.5rem;
   font-weight: 400;
   color: ${getThemedColor('neutral', divsCollided ? 100 : 900)};
-  border-left: 0.0625rem solid ${getThemedColor('neutral', divsCollided ? 700 : 300)};
+  border-left: 0.0625rem solid
+    ${getThemedColor('neutral', divsCollided ? 700 : 300)};
   display: flex;
   align-items: center;
   justify-content: center;
@@ -174,7 +175,8 @@ export const navbarActionsContainerStyles = (divsCollided: boolean) => css`
   justify-content: flex-end;
   gap: 1.25rem;
   padding-left: 1rem;
-  border-left: 0.0625rem solid ${getThemedColor('neutral', divsCollided ? 700 : 300)};
+  border-left: 0.0625rem solid
+    ${getThemedColor('neutral', divsCollided ? 700 : 300)};
 `
 
 export const navbarMenuActionStyles = (
@@ -194,8 +196,8 @@ export const navbarMenuActionStyles = (
 
   &:hover {
     background-color: ${theme === 'dark'
-    ? 'default'
-    : getThemedColor('neutral', 200)};
+      ? 'default'
+      : getThemedColor('neutral', 200)};
   }
 
   &:focus-visible {

--- a/src/components/Navigation/Navbar/styles.ts
+++ b/src/components/Navigation/Navbar/styles.ts
@@ -42,8 +42,8 @@ export const navbarSecondBarStyles = (
     : getThemedColor('neutral', 100)};
   border-bottom: 0.0625rem solid
     ${theme === 'dark'
-    ? getThemedColor('neutral', 800)
-    : getThemedColor('neutral', 400)};
+      ? getThemedColor('neutral', 800)
+      : getThemedColor('neutral', 400)};
   display: flex;
   align-items: center;
   justify-content: flex-start;
@@ -115,8 +115,8 @@ export const navbarLeftLinkStyles = (
 
   &:hover {
     background-color: ${theme === 'dark'
-    ? 'default'
-    : getThemedColor('neutral', 200)};
+      ? 'default'
+      : getThemedColor('neutral', 200)};
   }
 
   &:focus-visible {
@@ -196,8 +196,8 @@ export const navbarMenuActionStyles = (
 
   &:hover {
     background-color: ${theme === 'dark'
-    ? 'default'
-    : getThemedColor('neutral', 200)};
+      ? 'default'
+      : getThemedColor('neutral', 200)};
   }
 
   &:focus-visible {

--- a/src/components/Navigation/Navbar/types.ts
+++ b/src/components/Navigation/Navbar/types.ts
@@ -1,6 +1,7 @@
 import { ButtonProps } from '../../Forms/Actions/Button/types'
 import { MenuItemProps } from '../../Forms/Actions/Menu/types'
 import type { NavbarLabels } from '../../../lib/i18n/types'
+import type { SizeValue } from '../../../lib/sizing'
 
 export type { NavbarLabels }
 
@@ -28,7 +29,7 @@ export type NavbarProps = {
     size?: ButtonProps['size']
     onClick?: ButtonProps['onClick']
   }[]
-  maxWidth?: number
+  maxWidth?: SizeValue
   fixed?: boolean
   onNavbarHeightChange?: (height: number) => void
   backgroundColor?: string

--- a/src/components/Navigation/NavigationRail/index.tsx
+++ b/src/components/Navigation/NavigationRail/index.tsx
@@ -44,7 +44,7 @@ const NavigationRail = ({
       onOpenChange(!open)
     }
   }
-  const [isMobile] = useMediaQuery(['(max-width: 768px)'])
+  const [isMobile] = useMediaQuery(['(max-width: 48rem)'])
   if (isMobile) {
     return (
       <Tabs.Root
@@ -56,8 +56,8 @@ const NavigationRail = ({
             display: 'flex',
             overflowX: 'auto',
             whiteSpace: 'nowrap',
-            padding: '8px',
-            gap: '8px',
+            padding: '0.5rem',
+            gap: '0.5rem',
           }}
         >
           {tabs.map((tab) => (
@@ -67,7 +67,7 @@ const NavigationRail = ({
               css={{
                 '--indicator-color': getThemedColor('primary', 500),
                 flexShrink: 0,
-                padding: '10px 16px',
+                padding: '0.625rem 1rem',
                 color: getThemedColor('neutral', 600),
                 '&[data-selected]': {
                   color: getThemedColor('neutral', 800),
@@ -92,9 +92,9 @@ const NavigationRail = ({
   return (
     <div
       style={{
-        height: 'calc(100vh - 48px - 56px)',
+        height: 'calc(100vh - 3rem - 3.5rem)',
         position: 'fixed',
-        top: '48px',
+        top: '3rem',
         left: 0,
         display: 'flex',
       }}
@@ -125,7 +125,7 @@ const NavigationRail = ({
                   display='flex'
                   alignItems='center'
                   flexDirection='column'
-                  gap='5px'
+                  gap='0.3125rem'
                   className='ds-tab-label'
                 >
                   {tab.icon ? (

--- a/src/components/Navigation/NavigationRail/styled.ts
+++ b/src/components/Navigation/NavigationRail/styled.ts
@@ -3,10 +3,10 @@ import { getThemedColor } from '../../../lib/theme'
 import { NavigationRailProps } from './types'
 
 export const navigationRailContainerStyles = css`
-  width: 64px;
+  width: 4rem;
   height: 100%;
   z-index: 100;
-  border-right: 1px solid ${getThemedColor('neutral', 300)};
+  border-right: 0.0625rem solid ${getThemedColor('neutral', 300)};
   background-color: ${getThemedColor('neutral', 200)};
   display: flex;
   flex-direction: column;
@@ -14,16 +14,16 @@ export const navigationRailContainerStyles = css`
 `
 
 export const navigationRailTabStyles = css`
-  width: 64px;
-  height: 64px;
+  width: 4rem;
+  height: 4rem;
   background-color: ${getThemedColor('neutral', 200)};
   border-radius: initial;
   border-style: solid;
-  border-width: 1px 1px 0px 0px;
+  border-width: 0.0625rem 0.0625rem 0rem 0rem;
   border-color: ${getThemedColor('neutral', 300)};
   cursor: pointer;
-  border-left: 2px solid transparent;
-  padding: 0 5px;
+  border-left: 0.125rem solid transparent;
+  padding: 0 0.3125rem;
   display: flex;
   align-items: center;
   justify-content: center;
@@ -39,21 +39,21 @@ export const navigationRailTabStyles = css`
   &:focus-visible {
     background-color: ${getThemedColor('neutral', 200)};
     outline-color: ${getThemedColor('primary', 700)};
-    outline-offset: 2px;
+    outline-offset: 0.125rem;
     box-shadow: none;
   }
 
   .ds-tab-label p {
-    font-size: 10px;
+    font-size: 0.625rem;
     font-weight: 400;
-    line-height: 14px;
+    line-height: 0.875rem;
     text-align: center;
     color: ${getThemedColor('neutral', 700)};
   }
 
   &[data-selected] {
     background-color: ${getThemedColor('neutral', 100)};
-    border-left: 2px solid ${getThemedColor('secondary', 500)};
+    border-left: 0.125rem solid ${getThemedColor('secondary', 500)};
 
     &:hover {
       background-color: ${getThemedColor('neutral', 200)};
@@ -62,7 +62,7 @@ export const navigationRailTabStyles = css`
     &:focus-visible {
       background-color: ${getThemedColor('neutral', 100)};
       outline-color: ${getThemedColor('primary', 700)};
-      outline-offset: 2px;
+      outline-offset: 0.125rem;
       box-shadow: none;
     }
 
@@ -111,8 +111,8 @@ export const navigationRailTabIconStyles = css`
   align-items: center;
 
   svg {
-    width: 16px;
-    height: 16px;
+    width: 1rem;
+    height: 1rem;
 
     path {
       fill: ${getThemedColor('neutral', 600)};
@@ -121,21 +121,21 @@ export const navigationRailTabIconStyles = css`
 `
 
 export const navigationRailTriggerStyles = css`
-  width: 64px;
-  height: 64px;
+  width: 4rem;
+  height: 4rem;
   background-color: ${getThemedColor('neutral', 200)};
   border-radius: initial;
   border-style: solid;
-  border-width: 1px 1px 0px 0px;
+  border-width: 0.0625rem 0.0625rem 0rem 0rem;
   border-color: ${getThemedColor('neutral', 300)};
   cursor: pointer;
-  border-left: 2px solid transparent;
-  padding: 0 5px;
+  border-left: 0.125rem solid transparent;
+  padding: 0 0.3125rem;
   display: flex;
   align-items: center;
   justify-content: center;
   flex-direction: column;
-  gap: 5px;
+  gap: 0.3125rem;
 
   &:hover {
     background-color: ${getThemedColor('neutral', 100)};
@@ -147,26 +147,26 @@ export const navigationRailTriggerStyles = css`
 
   &:focus-visible {
     outline-color: ${getThemedColor('primary', 700)};
-    outline-offset: 2px;
+    outline-offset: 0.125rem;
     box-shadow: none;
   }
 
   .ds-tab-label p {
-    font-size: 10px;
+    font-size: 0.625rem;
     font-weight: 400;
-    line-height: 14px;
+    line-height: 0.875rem;
     text-align: center;
     color: ${getThemedColor('neutral', 600)};
   }
 `
 
 export const navigationRailChildrenContainerStyles = css`
-  width: 320px;
+  width: 20rem;
   height: 100%;
   z-index: 100;
-  box-shadow: 2px 0px 2px 0px #0000000d;
+  box-shadow: 0.125rem 0rem 0.125rem 0rem #0000000d;
   background-color: ${getThemedColor('neutral', 100)};
   overflow-y: auto;
   overflow-x: hidden;
-  border-right: 1px solid ${getThemedColor('neutral', 300)};
+  border-right: 0.0625rem solid ${getThemedColor('neutral', 300)};
 `

--- a/src/components/Navigation/Pagination/PaginationDemo.tsx
+++ b/src/components/Navigation/Pagination/PaginationDemo.tsx
@@ -6,7 +6,7 @@ import DemoWrapper from '../../UI/DemoWrapper'
 
 const PaginationDemo = () => (
   <DemoWrapper title='Pagination'>
-    <div style={{ display: 'flex', flexDirection: 'column', gap: '20px' }}>
+    <div style={{ display: 'flex', flexDirection: 'column', gap: '1.25rem' }}>
       <Pagination totalItems={50} pageSize={10} currentPage={1} />
       <Pagination
         totalItems={50}

--- a/src/components/Navigation/Pagination/styles.ts
+++ b/src/components/Navigation/Pagination/styles.ts
@@ -10,16 +10,16 @@ export const paginationPrevNextStyles = css`
 `
 
 export const paginationLabelCompactStyles = css`
-  font-size: 16px;
-  line-height: 24px;
+  font-size: 1rem;
+  line-height: 1.5rem;
   font-weight: 700;
   color: ${getThemedColor('neutral', 900)};
 `
 
 export const paginationLabelsGroupStyles = css`
   span {
-    height: 20px;
-    width: 20px;
+    height: 1.25rem;
+    width: 1.25rem;
     cursor: initial;
 
     &:hover {
@@ -29,8 +29,8 @@ export const paginationLabelsGroupStyles = css`
 `
 
 export const paginationLabelStyles = css`
-  font-size: 16px;
-  line-height: 24px;
+  font-size: 1rem;
+  line-height: 1.5rem;
   font-weight: 400;
   color: ${getThemedColor('neutral', 700)};
 

--- a/src/components/Navigation/Search/Search.stories.tsx
+++ b/src/components/Navigation/Search/Search.stories.tsx
@@ -104,7 +104,7 @@ export const CustomResultsRendering: Story = {
     displayResults: 'custom',
     renderResults: ({ items, query, highlightedIndex, onSelect }) => (
       <div>
-        <Box padding='6px 8px'>
+        <Box padding='0.375rem 0.5rem'>
           Recent searches
           <TextResults
             highlightedIndex={highlightedIndex}
@@ -147,7 +147,7 @@ export const MaxHeightResults: Story = {
   args: {
     options: sampleOptions,
     placeholder: 'Max Height Results',
-    resultsMaxHeight: '70px',
+    resultsMaxHeight: '4.375rem',
   },
 }
 

--- a/src/components/Navigation/Search/Search.stories.tsx
+++ b/src/components/Navigation/Search/Search.stories.tsx
@@ -85,9 +85,7 @@ export const Default: Story = {
   args: {
     options: sampleOptions,
     placeholder: 'Search',
-    onSelect: (option) => {
-      console.log('Selected option:', option)
-    },
+    onSelect: () => {},
   },
 }
 
@@ -115,9 +113,7 @@ export const CustomResultsRendering: Story = {
         </Box>
       </div>
     ),
-    onSelect: (option) => {
-      console.log('Selected option:', option)
-    },
+    onSelect: () => {},
   },
 }
 

--- a/src/components/Navigation/Search/SearchDemo.tsx
+++ b/src/components/Navigation/Search/SearchDemo.tsx
@@ -40,7 +40,7 @@ const sampleOptions = [
 
 const SearchDemo = () => (
   <DemoWrapper title='Search'>
-    <Box display='flex' flexDirection='column' gap='20px' width='400px'>
+    <Box display='flex' flexDirection='column' gap='1.25rem' width='25rem'>
       {/* Default Search */}
       <Search
         options={sampleOptions}
@@ -63,7 +63,7 @@ const SearchDemo = () => (
         displayResults='custom'
         renderResults={({ items, query, highlightedIndex, onSelect }) => (
           <div>
-            <Box padding='6px 8px'>
+            <Box padding='0.375rem 0.5rem'>
               Recent searches
               <TextResults
                 highlightedIndex={highlightedIndex}
@@ -104,8 +104,8 @@ const SearchDemo = () => (
       {/* Max Height Results */}
       <Search
         options={sampleOptions}
-        placeholder='7. Max Height Results (70px)'
-        resultsMaxHeight='70px'
+        placeholder='7. Max Height Results (4.375rem)'
+        resultsMaxHeight='4.375rem'
         onSelect={(option) => console.log({ selected: option })}
       />
 

--- a/src/components/Navigation/Search/TextResults.tsx
+++ b/src/components/Navigation/Search/TextResults.tsx
@@ -41,12 +41,12 @@ const TextResults = ({
     }
   }, [highlightedIndex])
   return (
-    <Box padding='8px'>
+    <Box padding='0.5rem'>
       {items.map((item, index) => (
         <Box
           ref={resultsRef}
           key={item.id}
-          padding='6px 8px'
+          padding='0.375rem 0.5rem'
           borderRadius='md'
           cursor='pointer'
           bg={index === highlightedIndex ? 'gray.100' : undefined}

--- a/src/components/Navigation/Search/index.tsx
+++ b/src/components/Navigation/Search/index.tsx
@@ -17,13 +17,14 @@ import { SearchIcon } from '../../icons'
 import { SearchProps } from './types'
 import { getThemedColor } from '../../../lib/theme'
 import { useLabels } from '../../../lib/i18n/useLabels'
+import { sizeValueToCss } from '../../../lib/sizing'
 
 const Search = ({
   placeholder,
   disabled,
   size = 'default',
   options = [],
-  resultsMaxHeight = '200px',
+  resultsMaxHeight = 50,
   isLoading = false,
   displayResults = 'text',
   onSelect,
@@ -109,7 +110,7 @@ const Search = ({
   }, [open])
 
   const endElement = filterText.length ? (
-    <CloseButton style={{ marginTop: '8px' }} onClick={handleOnClear} />
+    <CloseButton style={{ marginTop: '0.5rem' }} onClick={handleOnClear} />
   ) : null
 
   const resultsVisible =
@@ -124,7 +125,8 @@ const Search = ({
   } else if (isFocused) {
     iconFillColor = getThemedColor('primary', 700)
   }
-  const iconSize = size === 'small' ? '16px' : '20px'
+  const iconSize = size === 'small' ? '1rem' : '1.25rem'
+  const normalizedResultsMaxHeight = sizeValueToCss(resultsMaxHeight)
   return (
     <div ref={containerRef} style={{ position: 'relative', width: '100%' }}>
       <InputGroup
@@ -133,7 +135,7 @@ const Search = ({
             width={iconSize}
             height={iconSize}
             fill={iconFillColor}
-            style={{ marginTop: '8px' }}
+            style={{ marginTop: '0.5rem' }}
           />
         }
         endElement={endElement}
@@ -147,7 +149,7 @@ const Search = ({
           value={filterText}
           label=''
           style={{
-            paddingLeft: '40px',
+            paddingLeft: '2.5rem',
             borderColor: getThemedColor('neutral', 500),
           }}
           type='search'
@@ -208,12 +210,12 @@ const Search = ({
             position='absolute'
             width='100%'
             backgroundColor='white'
-            border={displayResults === 'custom' ? 'none' : '1px solid'}
+            border={displayResults === 'custom' ? 'none' : '0.0625rem solid'}
             borderColor='gray.200'
             borderRadius='md'
             zIndex={1000}
             overflowY='auto'
-            maxHeight={resultsMaxHeight}
+            maxHeight={normalizedResultsMaxHeight}
           >
             {isLoading && (
               <Box padding='1rem'>

--- a/src/components/Navigation/Search/index.tsx
+++ b/src/components/Navigation/Search/index.tsx
@@ -17,7 +17,7 @@ import { SearchIcon } from '../../icons'
 import { SearchProps } from './types'
 import { getThemedColor } from '../../../lib/theme'
 import { useLabels } from '../../../lib/i18n/useLabels'
-import { sizeValueToCss } from '../../../lib/sizing'
+import { resolveSizeValue } from '../../../lib/sizing'
 
 const Search = ({
   placeholder,
@@ -126,7 +126,7 @@ const Search = ({
     iconFillColor = getThemedColor('primary', 700)
   }
   const iconSize = size === 'small' ? '1rem' : '1.25rem'
-  const normalizedResultsMaxHeight = sizeValueToCss(resultsMaxHeight)
+  const normalizedResultsMaxHeight = resolveSizeValue(resultsMaxHeight)
   return (
     <div ref={containerRef} style={{ position: 'relative', width: '100%' }}>
       <InputGroup

--- a/src/components/Navigation/Search/types.ts
+++ b/src/components/Navigation/Search/types.ts
@@ -1,6 +1,7 @@
 import { InputProps as ChakraInputProps } from '@chakra-ui/react'
 import { ListItemProps } from '../../DataDisplay/List/types'
 import type { SearchLabels } from '../../../lib/i18n/types'
+import type { SizeValue } from '../../../lib/sizing'
 
 export type { SearchLabels }
 
@@ -12,7 +13,7 @@ export type SearchProps = Omit<
   disabled?: boolean
   size?: 'small' | 'default'
   options: ListItemProps[]
-  resultsMaxHeight?: string
+  resultsMaxHeight?: SizeValue
   isLoading?: boolean
   displayResults?: 'none' | 'text' | 'list' | 'custom'
   onSelect?: (selectedOption: ListItemProps) => void

--- a/src/components/Navigation/TabBar/TabBarDemo.tsx
+++ b/src/components/Navigation/TabBar/TabBarDemo.tsx
@@ -6,7 +6,7 @@ import DemoWrapper from '../../UI/DemoWrapper'
 
 const TabBarDemo = () => (
   <DemoWrapper title='Tab Bar'>
-    <div style={{ width: '100%', maxWidth: '300px' }}>
+    <div style={{ width: '100%', maxWidth: '18.75rem' }}>
       <TabBar
         variant='panel'
         tabs={[

--- a/src/components/Navigation/TabBar/index.tsx
+++ b/src/components/Navigation/TabBar/index.tsx
@@ -78,7 +78,7 @@ const TabBar = ({
                 aria-label={tab['aria-label'] || tab.label}
                 {...tab}
               >
-                <Box display='flex' alignItems='center' gap='5px'>
+                <Box display='flex' alignItems='center' gap='0.3125rem'>
                   {tab.icon}
                   {tab.label}
                 </Box>

--- a/src/components/Navigation/TabBar/styled.ts
+++ b/src/components/Navigation/TabBar/styled.ts
@@ -6,40 +6,40 @@ export const tabBarContainerStyles = (variant: TabBarProps['variant']) => css`
   width: 100%;
   display: flex;
   align-items: center;
-  height: 40px;
+  height: 2.5rem;
 
   ${variant === 'view' &&
   `
-    border: 1px solid ${getThemedColor('neutral', 400)};
+    border: 0.0625rem solid ${getThemedColor('neutral', 400)};
     background-color: ${getThemedColor('neutral', 200)};
-    border-radius: 4px;
-    padding: 4px;
+    border-radius: 0.25rem;
+    padding: 0.25rem;
   `}
 
   ${variant === 'transparent' &&
   `
     border: none;
     background-color: transparent;
-    border-radius: 4px;
-    padding: 0px 16px;
+    border-radius: 0.25rem;
+    padding: 0rem 1rem;
 
     .chakra-tabs__list {
-      gap: 32px;
+      gap: 2rem;
     }
   `}
 `
 
 export const defaultTabStyles = css`
   width: 99%;
-  height: 40px;
-  padding: 8px 16px;
-  border-radius: 0px;
+  height: 2.5rem;
+  padding: 0.5rem 1rem;
+  border-radius: 0rem;
   display: flex;
   justify-content: center;
   align-items: center;
-  gap: 2px;
-  font-size: 16px;
-  line-height: 24px;
+  gap: 0.125rem;
+  font-size: 1rem;
+  line-height: 1.5rem;
   font-weight: 400;
 
   &:focus-visible {
@@ -62,10 +62,10 @@ export const tabBarItemPanelStyles = css`
   &:focus-visible {
     background-color: ${getThemedColor('neutral', 300)};
     outline-color: ${getThemedColor('primary', 700)};
-    outline-offset: 2px;
+    outline-offset: 0.125rem;
     box-shadow:
-      0 0 0 2px ${getThemedColor('neutral', 100)},
-      rgba(0, 0, 0, 0.05) 0px 2px 2px 4px;
+      0 0 0 0.125rem ${getThemedColor('neutral', 100)},
+      rgba(0, 0, 0, 0.05) 0rem 0.125rem 0.125rem 0.25rem;
   }
 
   &[data-selected] {
@@ -83,10 +83,10 @@ export const tabBarItemPanelStyles = css`
     &:focus-visible {
       background-color: ${getThemedColor('neutral', 100)};
       outline-color: ${getThemedColor('primary', 700)};
-      outline-offset: 2px;
+      outline-offset: 0.125rem;
       box-shadow:
-        0 0 0 2px ${getThemedColor('neutral', 100)},
-        rgba(0, 0, 0, 0.05) 0px 2px 2px 4px;
+        0 0 0 0.125rem ${getThemedColor('neutral', 100)},
+        rgba(0, 0, 0, 0.05) 0rem 0.125rem 0.125rem 0.25rem;
     }
 
     &::before {
@@ -107,62 +107,62 @@ export const tabBarItemPanelStyles = css`
 `
 
 export const tabBarItemViewDividerStyles = css`
-  width: 4px;
-  height: 24px;
+  width: 0.25rem;
+  height: 1.5rem;
   background-color: ${getThemedColor('neutral', 400)};
 `
 
 export const tabBarItemViewStyles = css`
-  height: 32px;
-  border-radius: 2px;
+  height: 2rem;
+  border-radius: 0.125rem;
   background-color: ${getThemedColor('neutral', 200)};
   color: ${getThemedColor('neutral', 700)};
 
   &:hover {
     background-color: ${getThemedColor('neutral', 300)};
-    box-shadow: 0px 1px 2px 0px #0000000d;
+    box-shadow: 0rem 0.0625rem 0.125rem 0rem #0000000d;
   }
 
   &:active {
     background-color: ${getThemedColor('neutral', 300)};
-    box-shadow: 0px 2px 4px -2px #0000001a;
-    box-shadow: 0px 4px 6px -1px #0000001a;
+    box-shadow: 0rem 0.125rem 0.25rem -0.125rem #0000001a;
+    box-shadow: 0rem 0.25rem 0.375rem -0.0625rem #0000001a;
   }
 
   &:focus-visible {
     outline-color: ${getThemedColor('primary', 700)};
-    outline-offset: 2px;
+    outline-offset: 0.125rem;
     box-shadow:
-      0 0 0 2px ${getThemedColor('neutral', 100)},
-      rgba(0, 0, 0, 0.05) 0px 2px 2px 4px;
+      0 0 0 0.125rem ${getThemedColor('neutral', 100)},
+      rgba(0, 0, 0, 0.05) 0rem 0.125rem 0.125rem 0.25rem;
   }
 
   &[data-selected] {
     background-color: ${getThemedColor('neutral', 100)};
-    border: 1px solid ${getThemedColor('neutral', 300)};
-    box-shadow: 0px 1px 2px 0px #0000000d;
+    border: 0.0625rem solid ${getThemedColor('neutral', 300)};
+    box-shadow: 0rem 0.0625rem 0.125rem 0rem #0000000d;
     color: ${getThemedColor('neutral', 900)};
 
     &:hover {
       background-color: ${getThemedColor('neutral', 200)};
-      border: 1px solid ${getThemedColor('neutral', 300)};
-      box-shadow: 0px 2px 4px -2px #0000001a;
-      box-shadow: 0px 4px 6px -1px #0000001a;
+      border: 0.0625rem solid ${getThemedColor('neutral', 300)};
+      box-shadow: 0rem 0.125rem 0.25rem -0.125rem #0000001a;
+      box-shadow: 0rem 0.25rem 0.375rem -0.0625rem #0000001a;
     }
 
     &:active {
       background-color: ${getThemedColor('neutral', 300)};
-      border: 1px solid ${getThemedColor('neutral', 300)};
-      box-shadow: 0px 2px 4px -2px #0000001a;
-      box-shadow: 0px 4px 6px -1px #0000001a;
+      border: 0.0625rem solid ${getThemedColor('neutral', 300)};
+      box-shadow: 0rem 0.125rem 0.25rem -0.125rem #0000001a;
+      box-shadow: 0rem 0.25rem 0.375rem -0.0625rem #0000001a;
     }
 
     &:focus-visible {
       outline-color: ${getThemedColor('primary', 700)};
-      outline-offset: 2px;
+      outline-offset: 0.125rem;
       box-shadow:
-        0 0 0 2px ${getThemedColor('neutral', 100)},
-        rgba(0, 0, 0, 0.05) 0px 2px 2px 4px;
+        0 0 0 0.125rem ${getThemedColor('neutral', 100)},
+        rgba(0, 0, 0, 0.05) 0rem 0.125rem 0.125rem 0.25rem;
     }
 
     &::before {
@@ -191,48 +191,48 @@ export const tabBarItemTransparentStyles = css`
   background-color: transparent;
   color: ${getThemedColor('neutral', 600)};
   width: auto;
-  padding: 0px;
+  padding: 0rem;
   justify-content: flex-start;
-  border-bottom: 2px solid transparent;
+  border-bottom: 0.125rem solid transparent;
 
   &:hover {
     background-color: ${getThemedColor('neutral', 100)};
-    border-bottom: 2px solid ${getThemedColor('primary', 500)};
+    border-bottom: 0.125rem solid ${getThemedColor('primary', 500)};
   }
 
   &:active {
     background-color: ${getThemedColor('neutral', 100)};
-    border-bottom: 2px solid ${getThemedColor('primary', 500)};
+    border-bottom: 0.125rem solid ${getThemedColor('primary', 500)};
   }
 
   &:focus-visible {
     background-color: ${getThemedColor('neutral', 100)};
-    border-bottom: 2px solid ${getThemedColor('primary', 500)};
+    border-bottom: 0.125rem solid ${getThemedColor('primary', 500)};
     outline-color: ${getThemedColor('primary', 700)};
-    outline-offset: 2px;
+    outline-offset: 0.125rem;
     box-shadow:
-      0 0 0 2px ${getThemedColor('neutral', 100)},
-      rgba(0, 0, 0, 0.05) 0px 2px 2px 4px;
+      0 0 0 0.125rem ${getThemedColor('neutral', 100)},
+      rgba(0, 0, 0, 0.05) 0rem 0.125rem 0.125rem 0.25rem;
   }
 
   &[data-selected] {
     background-color: ${getThemedColor('neutral', 100)};
-    border-bottom: 2px solid ${getThemedColor('primary', 500)};
+    border-bottom: 0.125rem solid ${getThemedColor('primary', 500)};
     color: ${getThemedColor('neutral', 800)};
 
     &:hover {
       background-color: ${getThemedColor('neutral', 100)};
-      border-bottom: 2px solid ${getThemedColor('primary', 500)};
+      border-bottom: 0.125rem solid ${getThemedColor('primary', 500)};
       color: ${getThemedColor('neutral', 800)};
     }
 
     &:focus-visible {
       background-color: ${getThemedColor('neutral', 100)};
       outline-color: ${getThemedColor('primary', 700)};
-      outline-offset: 2px;
+      outline-offset: 0.125rem;
       box-shadow:
-        0 0 0 2px ${getThemedColor('neutral', 100)},
-        rgba(0, 0, 0, 0.05) 0px 2px 2px 4px;
+        0 0 0 0.125rem ${getThemedColor('neutral', 100)},
+        rgba(0, 0, 0, 0.05) 0rem 0.125rem 0.125rem 0.25rem;
     }
 
     &::before {
@@ -245,7 +245,7 @@ export const tabBarItemTransparentStyles = css`
     color: ${getThemedColor('neutral', 400)};
 
     &:hover {
-      border-bottom: 2px solid transparent;
+      border-bottom: 0.125rem solid transparent;
     }
 
     &[data-selected] {
@@ -254,7 +254,7 @@ export const tabBarItemTransparentStyles = css`
       opacity: 1;
 
       &:hover {
-        border-bottom: 2px solid ${getThemedColor('primary', 500)};
+        border-bottom: 0.125rem solid ${getThemedColor('primary', 500)};
       }
     }
   }

--- a/src/lib/sizing.ts
+++ b/src/lib/sizing.ts
@@ -1,0 +1,13 @@
+const SPACE_SCALE_UNIT_REM = 0.25
+
+export type SizeValue = number | string
+
+const formatRemValue = (value: number): string =>
+  parseFloat(value.toFixed(4)).toString()
+
+export const sizeValueToCss = (value: SizeValue): string => {
+  if (typeof value === 'number') {
+    return `${formatRemValue(value * SPACE_SCALE_UNIT_REM)}rem`
+  }
+  return value
+}

--- a/src/lib/sizing.ts
+++ b/src/lib/sizing.ts
@@ -5,7 +5,7 @@ export type SizeValue = number | string
 const formatRemValue = (value: number): string =>
   parseFloat(value.toFixed(4)).toString()
 
-export const sizeValueToCss = (value: SizeValue): string => {
+export const resolveSizeValue = (value: SizeValue): string => {
   if (typeof value === 'number') {
     return `${formatRemValue(value * SPACE_SCALE_UNIT_REM)}rem`
   }


### PR DESCRIPTION
[Task Link](https://gfw.atlassian.net/jira/software/projects/DS/boards/59?selectedIssue=DS-282)

The main changes involve converting all px units to rem units to improve scalability and consistency across the application.

Additionally, I’d like to highlight the implementation of the sizeValueToCss function. This utility allows us to use spacing-related props (such as width) in a more flexible and standardized way, similar to how Chakra UI handles sizing.

With this approach, we can pass both numeric and fixed values:

width={1} → 4px (0.25rem)
width={4} → 16px (1rem)
width={2.5} → 10px (0.625rem)
width="100%"
width="100vw"
width="13px"