### PR TITLE
PR documentation guidelines + update workflows for PR handling

### DIFF
--- a/.claude/skills/pr-documentation/SKILL.md
+++ b/.claude/skills/pr-documentation/SKILL.md
@@ -9,12 +9,15 @@ When writing a PR description:
 2. Write a description following this format:
 
 ## What
+
 One sentence explaining what this PR does.
 
 ## Why
+
 Brief context on why this change is needed
 
 ## Changes
+
 - Bullet points of specific changes made
 - Group related changes together
 - Mention any files deleted or renamed

--- a/.claude/skills/pr-documentation/SKILL.md
+++ b/.claude/skills/pr-documentation/SKILL.md
@@ -1,0 +1,21 @@
+---
+name: pr-documentation
+description: Guidelines for writing PR documentation. Covers required content, formatting, and examples. Use when creating a pr, writing a pr or when the user ask to summarize changes for a pr.
+---
+
+When writing a PR description:
+
+1. Run `git diff main...HEAD` to see all changes on this branch
+2. Write a description following this format:
+
+## What
+One sentence explaining what this PR does.
+
+## Why
+Brief context on why this change is needed
+
+## Changes
+- Bullet points of specific changes made
+- Group related changes together
+- Mention any files deleted or renamed
+- Add some examples of before/after code where helpful

--- a/.claude/skills/pr-documentation/SKILL.md
+++ b/.claude/skills/pr-documentation/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: pr-documentation
-description: Guidelines for writing PR documentation. Covers required content, formatting, and examples. Use when creating a PR, writing a PR, or when the user asks to summarize changes for a PR.
+description: Guidelines for writing PR documentation. Covers required content, formatting, and examples. Use when the user asks to summarize changes for a PR.
 ---
 
 When writing a PR description:

--- a/.claude/skills/pr-documentation/SKILL.md
+++ b/.claude/skills/pr-documentation/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: pr-documentation
-description: Guidelines for writing PR documentation. Covers required content, formatting, and examples. Use when creating a pr, writing a pr or when the user ask to summarize changes for a pr.
+description: Guidelines for writing PR documentation. Covers required content, formatting, and examples. Use when creating a PR, writing a PR, or when the user asks to summarize changes for a PR.
 ---
 
 When writing a PR description:

--- a/.gemini/skills/pr-documentation/SKILL.md
+++ b/.gemini/skills/pr-documentation/SKILL.md
@@ -9,12 +9,15 @@ When writing a PR description:
 2. Write a description following this format:
 
 ## What
+
 One sentence explaining what this PR does.
 
 ## Why
+
 Brief context on why this change is needed
 
 ## Changes
+
 - Bullet points of specific changes made
 - Group related changes together
 - Mention any files deleted or renamed

--- a/.gemini/skills/pr-documentation/SKILL.md
+++ b/.gemini/skills/pr-documentation/SKILL.md
@@ -1,0 +1,21 @@
+---
+name: pr-documentation
+description: Guidelines for writing PR documentation. Covers required content, formatting, and examples. Use when creating a pr, writing a pr or when the user ask to summarize changes for a pr.
+---
+
+When writing a PR description:
+
+1. Run `git diff main...HEAD` to see all changes on this branch
+2. Write a description following this format:
+
+## What
+One sentence explaining what this PR does.
+
+## Why
+Brief context on why this change is needed
+
+## Changes
+- Bullet points of specific changes made
+- Group related changes together
+- Mention any files deleted or renamed
+- Add some examples of before/after code where helpful

--- a/.gemini/skills/pr-documentation/SKILL.md
+++ b/.gemini/skills/pr-documentation/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: pr-documentation
-description: Guidelines for writing PR documentation. Covers required content, formatting, and examples. Use when creating a PR, writing a PR, or when the user asks to summarize changes for a PR.
+description: Guidelines for writing PR documentation. Covers required content, formatting, and examples. Use when the user asks to summarize changes for a PR.
 ---
 
 When writing a PR description:

--- a/.gemini/skills/pr-documentation/SKILL.md
+++ b/.gemini/skills/pr-documentation/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: pr-documentation
-description: Guidelines for writing PR documentation. Covers required content, formatting, and examples. Use when creating a pr, writing a pr or when the user ask to summarize changes for a pr.
+description: Guidelines for writing PR documentation. Covers required content, formatting, and examples. Use when creating a PR, writing a PR, or when the user asks to summarize changes for a PR.
 ---
 
 When writing a PR description:

--- a/.github/workflows/lint-guard.yml
+++ b/.github/workflows/lint-guard.yml
@@ -15,7 +15,7 @@ concurrency:
 jobs:
   lint:
     name: Lint must be clean
-    if: github.event.pull_request.draft == false
+    if: github.event.pull_request.draft == false && !contains(join(github.event.pull_request.labels.*.name, ','), 'auto-release')
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/lint-guard.yml
+++ b/.github/workflows/lint-guard.yml
@@ -15,7 +15,7 @@ concurrency:
 jobs:
   lint:
     name: Lint must be clean
-    if: github.event.pull_request.draft == false && !contains(join(github.event.pull_request.labels.*.name, ','), 'auto-release')
+    if: github.event.pull_request.draft == false && !contains(github.event.pull_request.labels.*.name, 'auto-release')
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/lint-guard.yml
+++ b/.github/workflows/lint-guard.yml
@@ -3,7 +3,7 @@ name: Lint Guard
 on:
   pull_request:
     branches: [main]
-    types: [opened, synchronize, reopened]
+    types: [opened, synchronize, reopened, ready_for_review]
 
 permissions:
   contents: read
@@ -15,6 +15,7 @@ concurrency:
 jobs:
   lint:
     name: Lint must be clean
+    if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/pr-label-check.yml
+++ b/.github/workflows/pr-label-check.yml
@@ -3,7 +3,7 @@ name: PR Label Guard
 on:
   pull_request:
     branches: [main]
-    types: [opened, labeled, unlabeled, synchronize, reopened, edited]
+    types: [opened, labeled, unlabeled, synchronize, reopened, edited, ready_for_review]
 
 permissions:
   pull-requests: write

--- a/.github/workflows/pr-label-check.yml
+++ b/.github/workflows/pr-label-check.yml
@@ -4,15 +4,13 @@ on:
   pull_request:
     branches: [main]
     types:
-      [
-        opened,
-        labeled,
-        unlabeled,
-        synchronize,
-        reopened,
-        edited,
-        ready_for_review,
-      ]
+      - opened
+      - labeled
+      - unlabeled
+      - synchronize
+      - reopened
+      - edited
+      - ready_for_review
 
 permissions:
   pull-requests: write

--- a/.github/workflows/pr-label-check.yml
+++ b/.github/workflows/pr-label-check.yml
@@ -19,7 +19,7 @@ permissions:
 jobs:
   validate:
     name: Validate versioning label
-    if: ${{ !contains(join(github.event.pull_request.labels.*.name, ','), 'auto-release') }}
+    if: ${{ !contains(github.event.pull_request.labels.*.name, 'auto-release') }}
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/pr-label-check.yml
+++ b/.github/workflows/pr-label-check.yml
@@ -3,7 +3,16 @@ name: PR Label Guard
 on:
   pull_request:
     branches: [main]
-    types: [opened, labeled, unlabeled, synchronize, reopened, edited, ready_for_review]
+    types:
+      [
+        opened,
+        labeled,
+        unlabeled,
+        synchronize,
+        reopened,
+        edited,
+        ready_for_review,
+      ]
 
 permissions:
   pull-requests: write

--- a/.github/workflows/pr-label-check.yml
+++ b/.github/workflows/pr-label-check.yml
@@ -21,6 +21,7 @@ permissions:
 jobs:
   validate:
     name: Validate versioning label
+    if: ${{ !contains(join(github.event.pull_request.labels.*.name, ','), 'auto-release') }}
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/release-and-publish.yml
+++ b/.github/workflows/release-and-publish.yml
@@ -14,8 +14,7 @@ jobs:
     name: Create release PR
     if: >
       github.event.pull_request.merged == true &&
-      !startsWith(github.event.pull_request.head.ref, 'chore/release-v') &&
-      !startsWith(github.event.pull_request.title, 'chore(release):') &&
+      !contains(join(github.event.pull_request.labels.*.name, ','), 'auto-release') &&
       (
         contains(join(github.event.pull_request.labels.*.name, ','), 'patch') ||
         contains(join(github.event.pull_request.labels.*.name, ','), 'minor') ||
@@ -83,16 +82,14 @@ jobs:
 
             After merge, publish from this commit/tag.
           labels: |
+            auto-release
             ${{ steps.bump.outputs.bump }}
 
   publish_release:
     name: Tag, Publish & Create GitHub Release
     if: >
       github.event.pull_request.merged == true &&
-      (
-        startsWith(github.event.pull_request.head.ref, 'chore/release-v') ||
-        startsWith(github.event.pull_request.title, 'chore(release):')
-      )
+      contains(join(github.event.pull_request.labels.*.name, ','), 'auto-release')
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -161,7 +158,7 @@ jobs:
     name: Skip release (no-bump)
     if: >
       github.event.pull_request.merged == true &&
-      !startsWith(github.event.pull_request.head.ref, 'chore/release-v') &&
+      !contains(join(github.event.pull_request.labels.*.name, ','), 'auto-release') &&
       contains(join(github.event.pull_request.labels.*.name, ','), 'no-bump')
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/release-and-publish.yml
+++ b/.github/workflows/release-and-publish.yml
@@ -83,7 +83,7 @@ jobs:
 
             After merge, publish from this commit/tag.
           labels: |
-            patch
+            ${{ steps.bump.outputs.bump }}
 
   publish_release:
     name: Tag, Publish & Create GitHub Release
@@ -104,7 +104,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          ref: main
+          ref: ${{ github.event.pull_request.merge_commit_sha }}
 
       - name: Use Node
         uses: actions/setup-node@v4

--- a/.github/workflows/release-and-publish.yml
+++ b/.github/workflows/release-and-publish.yml
@@ -10,10 +10,12 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  release:
-    name: Bump, Tag, Publish & Release
+  create_release_pr:
+    name: Create release PR
     if: >
       github.event.pull_request.merged == true &&
+      !startsWith(github.event.pull_request.head.ref, 'chore/release-v') &&
+      !startsWith(github.event.pull_request.title, 'chore(release):') &&
       (
         contains(join(github.event.pull_request.labels.*.name, ','), 'patch') ||
         contains(join(github.event.pull_request.labels.*.name, ','), 'minor') ||
@@ -22,8 +24,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-      pull-requests: read
-      id-token: write
+      pull-requests: write
 
     steps:
       - name: Checkout repository
@@ -32,27 +33,10 @@ jobs:
           fetch-depth: 0
           ref: main
 
-      - name: Sync with origin/main
-        run: |
-          git fetch origin --prune
-          git checkout main
-          git pull --rebase origin main
-
       - name: Use Node
         uses: actions/setup-node@v4
         with:
           node-version-file: '.nvmrc'
-          registry-url: 'https://registry.npmjs.org'
-          cache: 'yarn'
-
-      - name: Install deps
-        run: yarn install --frozen-lockfile
-
-      - name: Lint & fix
-        run: yarn lint-fix
-
-      - name: Build
-        run: yarn build
 
       - name: Determine version bump from PR label
         id: bump
@@ -68,14 +52,13 @@ jobs:
               core.setOutput('bump', found);
             }
 
-      - name: Git config (bot user)
+      - name: Configure Git user
         run: |
-          git config user.name  "ds-wri-bot"
+          git config user.name "ds-wri-bot"
           git config user.email "ds-bot@wri.org"
 
-      - name: Bump version & create tag
-        run: |
-          npm version ${{ steps.bump.outputs.bump }} -m 'release: %s'
+      - name: Bump version (no tag)
+        run: npm version ${{ steps.bump.outputs.bump }} --no-git-tag-version
 
       - name: Read new version
         id: ver
@@ -83,16 +66,91 @@ jobs:
           VERSION=$(node -p "require('./package.json').version")
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
 
-      - name: Push commit & tags
+      - name: Create release PR
+        uses: peter-evans/create-pull-request@v6
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          branch: chore/release-v${{ steps.ver.outputs.version }}
+          base: main
+          commit-message: 'chore(release): v${{ steps.ver.outputs.version }}'
+          title: 'chore(release): v${{ steps.ver.outputs.version }}'
+          body: |
+            Automated release PR.
+
+            - Source PR: #${{ github.event.pull_request.number }}
+            - Version bump: `${{ steps.bump.outputs.bump }}`
+            - New version: `${{ steps.ver.outputs.version }}`
+
+            After merge, publish from this commit/tag.
+          labels: |
+            patch
+
+  publish_release:
+    name: Tag, Publish & Create GitHub Release
+    if: >
+      github.event.pull_request.merged == true &&
+      (
+        startsWith(github.event.pull_request.head.ref, 'chore/release-v') ||
+        startsWith(github.event.pull_request.title, 'chore(release):')
+      )
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: read
+      id-token: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: main
+
+      - name: Use Node
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: '.nvmrc'
+          registry-url: 'https://registry.npmjs.org'
+          cache: 'yarn'
+
+      - name: Install deps
+        run: yarn install --frozen-lockfile
+
+      - name: Build
+        run: yarn build
+
+      - name: Read version
+        id: ver
         run: |
-          git push origin main --follow-tags
+          VERSION=$(node -p "require('./package.json').version")
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Configure Git user
+        run: |
+          git config user.name "ds-wri-bot"
+          git config user.email "ds-bot@wri.org"
+
+      - name: Create and push tag
+        id: tag
+        run: |
+          TAG="v${{ steps.ver.outputs.version }}"
+          if git ls-remote --exit-code --tags origin "refs/tags/$TAG" >/dev/null 2>&1; then
+            echo "Tag $TAG already exists. Skipping tag creation."
+            echo "should_publish=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          git tag -a "$TAG" -m "release: $TAG"
+          git push origin "$TAG"
+          echo "should_publish=true" >> "$GITHUB_OUTPUT"
 
       - name: Publish to npm
+        if: steps.tag.outputs.should_publish == 'true'
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: npm publish --access public
 
       - name: Create GitHub Release (auto-notes)
+        if: steps.tag.outputs.should_publish == 'true'
         uses: softprops/action-gh-release@v2
         with:
           tag_name: v${{ steps.ver.outputs.version }}
@@ -103,6 +161,7 @@ jobs:
     name: Skip release (no-bump)
     if: >
       github.event.pull_request.merged == true &&
+      !startsWith(github.event.pull_request.head.ref, 'chore/release-v') &&
       contains(join(github.event.pull_request.labels.*.name, ','), 'no-bump')
     runs-on: ubuntu-latest
     permissions:
@@ -110,4 +169,4 @@ jobs:
     steps:
       - uses: mshick/add-pr-comment@v2
         with:
-          message: '🚨 Release skipped: PR labeled **no-bump**. No version bump, tag, or publish.'
+          message: '🚨 Release skipped: PR labeled **no-bump**. No version bump PR was created.'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ concurrency:
 jobs:
   test:
     name: Tests must pass
-    if: github.event.pull_request.draft == false
+    if: github.event.pull_request.draft == false && !contains(join(github.event.pull_request.labels.*.name, ','), 'auto-release')
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ concurrency:
 jobs:
   test:
     name: Tests must pass
-    if: github.event.pull_request.draft == false && !contains(join(github.event.pull_request.labels.*.name, ','), 'auto-release')
+    if: github.event.pull_request.draft == false && !contains(github.event.pull_request.labels.*.name, 'auto-release')
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,7 +3,7 @@ name: Test
 on:
   pull_request:
     branches: [main]
-    types: [opened, synchronize, reopened]
+    types: [opened, synchronize, reopened, ready_for_review]
 
 permissions:
   contents: read
@@ -15,6 +15,7 @@ concurrency:
 jobs:
   test:
     name: Tests must pass
+    if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
 
     steps:

--- a/README.md
+++ b/README.md
@@ -493,3 +493,15 @@ Use exactly one versioning label on every PR. The label drives the npm version b
 - `no-bump`: documentation-only or internal changes that should not publish
 
 If you are unsure, choose `minor` and leave a note in the PR for review.
+
+## PR Description With AI Skill
+
+To get a solid PR description quickly, use the `pr-documentation` skill in your AI-enabled editor.
+
+1. Ensure your branch is up to date and run:
+`git diff main...HEAD`
+2. Ask the assistant to use `pr-documentation` and summarize the current PR changes. Or ask "create a pr description for my changes"
+3. Paste the generated result into the PR description using this structure:
+`## What`, `## Why`, `## Changes`.
+
+The `pr-documentation` skill is defined at `[.gemini or .claude]/skills/pr-documentation/SKILL.md` and is tailored for this repository workflow.

--- a/README.md
+++ b/README.md
@@ -476,14 +476,18 @@ npm publish
 
 ## PR Label Rules
 
-Use exactly one versioning label on every PR. The label drives the npm version bump when the PR is merged into `main`.
+Use exactly one versioning label on every contributor PR. The label drives the npm version bump workflow when the PR is merged into `main`.
 
 **How it works**
 
 - Open a PR and add **one** of the labels below.
 - The PR Label Guard workflow enforces that exactly one label is present.
-- On merge, the Release & Publish workflow bumps `package.json`, tags, and publishes to npm for `major`, `minor`, or `patch`.
+- On merge, the Release & Publish workflow opens an automated release PR with labels:
+  - `auto-release`
+  - the same bump label from the merged PR (`major`, `minor`, or `patch`)
+- Merge that release PR to trigger tag creation, npm publish, and GitHub release notes.
 - `no-bump` skips all versioning and publishing.
+- PR checks (`test`, `lint`, `pr-label-check`) are skipped for PRs labeled `auto-release`.
 
 **Label guide**
 
@@ -491,6 +495,7 @@ Use exactly one versioning label on every PR. The label drives the npm version b
 - `minor`: backwards-compatible feature or API additions (new component/prop), or behavior changes that may affect usage but are not breaking
 - `major`: breaking changes (removed/renamed props, changed required behavior, incompatible defaults)
 - `no-bump`: documentation-only or internal changes that should not publish
+- `auto-release`: internal automation label for generated release PRs (do not use manually on regular PRs)
 
 If you are unsure, choose `minor` and leave a note in the PR for review.
 
@@ -500,8 +505,8 @@ To get a solid PR description quickly, use the `pr-documentation` skill in your 
 
 1. Ensure your branch is up to date and run:
    `git diff main...HEAD`
-2. Ask the assistant to use `pr-documentation` and summarize the current PR changes. Or ask "create a pr description for my changes"
+2. Ask the assistant to use `pr-documentation` and summarize the current PR changes. Or ask "create a PR description for my changes"
 3. Paste the generated result into the PR description using this structure:
    `## What`, `## Why`, `## Changes`.
 
-The `pr-documentation` skill is defined at `[.gemini or .claude]/skills/pr-documentation/SKILL.md` and is tailored for this repository workflow.
+The `pr-documentation` skill is defined at [`.gemini/skills/pr-documentation/SKILL.md`](.gemini/skills/pr-documentation/SKILL.md) and [`.claude/skills/pr-documentation/SKILL.md`](.claude/skills/pr-documentation/SKILL.md) and is tailored for this repository workflow.

--- a/README.md
+++ b/README.md
@@ -499,9 +499,9 @@ If you are unsure, choose `minor` and leave a note in the PR for review.
 To get a solid PR description quickly, use the `pr-documentation` skill in your AI-enabled editor.
 
 1. Ensure your branch is up to date and run:
-`git diff main...HEAD`
+   `git diff main...HEAD`
 2. Ask the assistant to use `pr-documentation` and summarize the current PR changes. Or ask "create a pr description for my changes"
 3. Paste the generated result into the PR description using this structure:
-`## What`, `## Why`, `## Changes`.
+   `## What`, `## Why`, `## Changes`.
 
 The `pr-documentation` skill is defined at `[.gemini or .claude]/skills/pr-documentation/SKILL.md` and is tailored for this repository workflow.


### PR DESCRIPTION
## What
Updates GitHub workflow triggers to handle draft PRs and reworks the automated release process to use an intermediate release PR.

## Why
To optimize CI usage by skipping lint and test jobs on draft PRs until they are ready for review, and to introduce a safer, two-step release workflow where versions are bumped in a dedicated release PR before being tagged and published. 

## Changes

**GitHub Actions Workflows:**
- **Release & Publish (``release-and-publish.yml``)**:
  - Splits the single-step release process into two distinct jobs: `create_release_pr` and `publish_release`.
  - The `create_release_pr` job now bumps the version (without tagging) and opens an automated ``chore/release-v`*` PR instead of directly tagging and pushing to main.
  - The `publish_release` job triggers when the release PR is merged, handling the actual Git tag creation, npm publishing, and GitHub Release generation.
  - Updates the "no-bump" skip job message to reflect the new PR-based flow.
- **CI Guards (``lint-guard.yml``, ``test.yml``, ``pr-label-check.yml``)**:
  - Adds the `ready_for_review` activity type to trigger the workflows.
  - Adds an `if: `github.event.pull_request.draft` == false` condition to the `lint-guard` and `test` jobs so they don't consume runner time on draft PRs.

**AI Tooling:**
- Adds the `pr-documentation` AI skill definition to ``.claude/skills`` and ``.gemini/skills`` to assist AI agents in generating standardized PR summaries.
