### PR TITLE
enhance deployment workflow with auto-release detection and update release PR commit message format

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -32,24 +32,32 @@ jobs:
             const { owner, repo } = context.repo;
             const commitSha = context.sha;
 
-            const pulls = await github.request(
-              'GET /repos/{owner}/{repo}/commits/{commit_sha}/pulls',
-              {
-                owner,
-                repo,
-                commit_sha: commitSha,
-                mediaType: { previews: ['groot'] }
-              }
-            );
+            let skip = 'false';
 
-            const pr = (pulls.data || [])[0];
-            if (!pr) {
-              core.setOutput('skip', 'false');
-              return;
+            try {
+              const pulls = await github.request(
+                'GET /repos/{owner}/{repo}/commits/{commit_sha}/pulls',
+                {
+                  owner,
+                  repo,
+                  commit_sha: commitSha,
+                  mediaType: { previews: ['groot'] }
+                }
+              );
+
+              const pr = (pulls.data || [])[0];
+              if (!pr) {
+                core.setOutput('skip', skip);
+                return;
+              }
+
+              const labels = (pr.labels || []).map((l) => String(l.name).toLowerCase());
+              skip = labels.includes('auto-release') ? 'true' : 'false';
+            } catch (error) {
+              core.warning(`Unable to detect auto-release label for commit ${commitSha}: ${error.message}`);
             }
 
-            const labels = (pr.labels || []).map((l) => String(l.name).toLowerCase());
-            core.setOutput('skip', labels.includes('auto-release') ? 'true' : 'false');
+            core.setOutput('skip', skip);
 
   build:
     needs: detect_auto_release

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -19,7 +19,41 @@ env:
   PUBLISH_DIR: public
 
 jobs:
+  detect_auto_release:
+    runs-on: ubuntu-latest
+    outputs:
+      skip: ${{ steps.detect.outputs.skip }}
+    steps:
+      - name: Detect auto-release label on merged PR
+        id: detect
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const { owner, repo } = context.repo;
+            const commitSha = context.sha;
+
+            const pulls = await github.request(
+              'GET /repos/{owner}/{repo}/commits/{commit_sha}/pulls',
+              {
+                owner,
+                repo,
+                commit_sha: commitSha,
+                mediaType: { previews: ['groot'] }
+              }
+            );
+
+            const pr = (pulls.data || [])[0];
+            if (!pr) {
+              core.setOutput('skip', 'false');
+              return;
+            }
+
+            const labels = (pr.labels || []).map((l) => String(l.name).toLowerCase());
+            core.setOutput('skip', labels.includes('auto-release') ? 'true' : 'false');
+
   build:
+    needs: detect_auto_release
+    if: ${{ needs.detect_auto_release.outputs.skip != 'true' }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -61,10 +95,11 @@ jobs:
           path: ${{ env.PUBLISH_DIR }}
 
   deploy:
+    needs: [detect_auto_release, build]
+    if: ${{ needs.detect_auto_release.outputs.skip != 'true' }}
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
-    needs: build
     runs-on: ubuntu-latest
     steps:
       - name: Deploy to GitHub Pages

--- a/.github/workflows/release-and-publish.yml
+++ b/.github/workflows/release-and-publish.yml
@@ -69,10 +69,10 @@ jobs:
         uses: peter-evans/create-pull-request@v6
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          branch: chore/release-v${{ steps.ver.outputs.version }}
+          branch: release-v${{ steps.ver.outputs.version }}
           base: main
-          commit-message: 'chore(release): v${{ steps.ver.outputs.version }}'
-          title: 'chore(release): v${{ steps.ver.outputs.version }}'
+          commit-message: 'release: v${{ steps.ver.outputs.version }}'
+          title: 'release: v${{ steps.ver.outputs.version }}'
           body: |
             Automated release PR.
 


### PR DESCRIPTION
## What
Enhances the deployment workflow to skip builds on auto-release PRs and updates the release PR formatting.

## Why
To prevent redundant build and deploy jobs from running when an automated release PR is merged, and to clean up the branch names and commit messages generated by the release workflow.

## Changes
- **Deploy Workflow (``deploy.yaml``)**:
  - Adds a new `detect_auto_release` job that uses the GitHub API to check if the commit was merged from a PR with the `auto-release` label.
  - Updates the `build` and `deploy` jobs to depend on `detect_auto_release` and skip execution if the `auto-release` label is detected.
- **Release Workflow (``release-and-publish.yml``)**:
  - Updates the automated release PR branch name from ``chore/release-v`*` to `release-v*`.
  - Updates the commit message and PR title from `chore(release): v*` to `release: v*`.