### PR TITLE
enable auto-merge for release pull requests

### DIFF
--- a/.github/workflows/release-and-publish.yml
+++ b/.github/workflows/release-and-publish.yml
@@ -66,6 +66,7 @@ jobs:
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
 
       - name: Create release PR
+        id: create_pr
         uses: peter-evans/create-pull-request@v6
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -85,11 +86,32 @@ jobs:
             auto-release
             ${{ steps.bump.outputs.bump }}
 
+      - name: Enable auto-merge on release PR
+        if: ${{ steps.create_pr.outputs.pull-request-number != '' }}
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const pull_number = Number('${{ steps.create_pr.outputs.pull-request-number }}');
+            const { owner, repo } = context.repo;
+            const pr = await github.rest.pulls.get({ owner, repo, pull_number });
+            await github.graphql(
+              `mutation($pullRequestId: ID!) {
+                enablePullRequestAutoMerge(input: {
+                  pullRequestId: $pullRequestId,
+                  mergeMethod: SQUASH
+                }) {
+                  pullRequest { number }
+                }
+              }`,
+              { pullRequestId: pr.data.node_id }
+            );
+
   publish_release:
     name: Tag, Publish & Create GitHub Release
     if: >
       github.event.pull_request.merged == true &&
-      contains(join(github.event.pull_request.labels.*.name, ','), 'auto-release')
+      contains(join(github.event.pull_request.labels.*.name, ','), 'auto-release') &&
+      startsWith(github.event.pull_request.head.ref, 'release-v')
     runs-on: ubuntu-latest
     permissions:
       contents: write


### PR DESCRIPTION
## What
Enable automatic merging for release PRs and limit release publishing to release branches.

## Why
Release PRs should not require manual merge handling, and release publishing should only run for the intended release branch flow to avoid accidental publishes.

## Changes
- Added an id to the release PR creation step so the workflow can read the created PR number.
- Added a GitHub script step that enables auto-merge on the generated release PR using squash merge.
- Tightened the publish_release job condition so it only runs when:
  - the PR is merged,
  - the auto-release label is present,
  - and the source branch starts with release-v.