### PR TITLE
add support for left and right icons in MultiActionButton demos and update READMEs

### DIFF
--- a/src/components/DataDisplay/List/README.md
+++ b/src/components/DataDisplay/List/README.md
@@ -38,22 +38,25 @@ const items = [
 ## Props
 
 ```ts
-export type ListItemVariant = 'data' | 'navigation'
+export type ListItemVariant = 'data' | 'navigation' | 'select'
 
 export interface ListItemProps {
   id?: string
   label: string
   caption?: string
   icon?: ReactElement
-  value?: string
+  value?: React.ReactNode
   variant?: ListItemVariant
   isExpanded?: boolean
   onItemClick?: () => void
   ariaLabel?: string
+  disabled?: boolean
+  isHighlighted?: boolean
 }
 
 export interface ListProps {
   items: ListItemProps[]
   noBorder?: boolean
+  highlightedIndex?: number
 }
 ```

--- a/src/components/Forms/Actions/MultiActionButton/MultiActionButton.stories.tsx
+++ b/src/components/Forms/Actions/MultiActionButton/MultiActionButton.stories.tsx
@@ -5,6 +5,7 @@ import React from 'react'
 import type { Meta, StoryObj } from '@storybook/react'
 import { fn } from '@storybook/test'
 import MultiActionButton from '.'
+import { InfoIcon } from '../../../icons'
 
 const meta = {
   title: 'Forms/Actions/Multi Action Button',
@@ -159,5 +160,47 @@ export const Disabled: Story = {
       },
     ],
     disabled: true,
+  },
+}
+
+export const WithLeftIcon: Story = {
+  args: {
+    variant: 'primary',
+    mainActionLabel: 'First Action',
+    mainActionLeftIcon: <InfoIcon />,
+    mainActionOnClick: () => console.log('first action'),
+    otherActions: [
+      {
+        label: 'Second Action',
+        value: 'second-action',
+        onClick: () => console.log('second action'),
+      },
+      {
+        label: 'Third Action',
+        value: 'third-action',
+        onClick: () => console.log('third action'),
+      },
+    ],
+  },
+}
+
+export const WithRightIcon: Story = {
+  args: {
+    variant: 'secondary',
+    mainActionLabel: 'First Action',
+    mainActionRightIcon: <InfoIcon />,
+    mainActionOnClick: () => console.log('first action'),
+    otherActions: [
+      {
+        label: 'Second Action',
+        value: 'second-action',
+        onClick: () => console.log('second action'),
+      },
+      {
+        label: 'Third Action',
+        value: 'third-action',
+        onClick: () => console.log('third action'),
+      },
+    ],
   },
 }

--- a/src/components/Forms/Actions/MultiActionButton/MultiActionButtonDemo.tsx
+++ b/src/components/Forms/Actions/MultiActionButton/MultiActionButtonDemo.tsx
@@ -1,5 +1,6 @@
 /* eslint-disable no-console */
 import { MultiActionButton } from '../../..'
+import { InfoIcon } from '../../../icons'
 import DemoWrapper from '../../../UI/DemoWrapper'
 
 const MultiActionButtonDemo = () => (
@@ -75,6 +76,42 @@ const MultiActionButtonDemo = () => (
           variant='secondary'
           size='small'
           mainActionLabel='First Action'
+          mainActionOnClick={() => console.log('first action')}
+          otherActions={[
+            {
+              label: 'Second Action',
+              value: 'second-action',
+              onClick: () => console.log('second action'),
+            },
+          ]}
+        />
+      </div>
+      <div
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          gap: '0.625rem',
+          flexWrap: 'wrap',
+        }}
+      >
+        <MultiActionButton
+          variant='primary'
+          mainActionLeftIcon={<InfoIcon />}
+          mainActionLabel='First Action'
+          mainActionOnClick={() => console.log('first action')}
+          otherActions={[
+            {
+              label: 'Second Action',
+              value: 'second-action',
+              onClick: () => console.log('second action'),
+            },
+          ]}
+        />
+        <MultiActionButton
+          variant='secondary'
+          size='small'
+          mainActionLabel='First Action'
+          mainActionRightIcon={<InfoIcon />}
           mainActionOnClick={() => console.log('first action')}
           otherActions={[
             {

--- a/src/components/Forms/Actions/MultiActionButton/README.md
+++ b/src/components/Forms/Actions/MultiActionButton/README.md
@@ -41,6 +41,8 @@ type MultiActionButtonProps = Omit<
 > & {
   variant?: 'primary' | 'secondary'
   size?: 'default' | 'small'
+  mainActionLeftIcon?: React.ReactNode
+  mainActionRightIcon?: React.ReactNode
   mainActionLabel: string
   mainActionOnClick: VoidFunction
   otherActions: {


### PR DESCRIPTION
## What

This PR updates the documentation, stories, and demo examples for the `List` and `MultiActionButton` components to reflect newly added props and capabilities.

## Why

These updates ensure that the component documentation is synchronized with the latest source code additions, specifically for the new selection/highlight states in `List` and icon support in `MultiActionButton`. This helps other developers correctly use these new features.

## Changes

**List Component Updates**
- Updated `ListItemVariant` to include the `'select'` variant in ``README.md``.
- Broadened the type of `value` in `ListItemProps` from `string` to ``React.ReactNode``.
- Documented the new `disabled` and `isHighlighted` boolean props in `ListItemProps`.
- Documented the new `highlightedIndex` prop in `ListProps`.
  - *Before*: `value?: string`
  - *After*: `value?: `React.ReactNode``

**MultiActionButton Component Updates**
- Documented the new `mainActionLeftIcon` and `mainActionRightIcon` props (type ``React.ReactNode``) in ``README.md``.
- Added `WithLeftIcon` and `WithRightIcon` stories to ``MultiActionButton.stories.tsx`` to showcase the new functionality.
- Updated ``MultiActionButtonDemo.tsx`` with examples demonstrating primary and secondary variants utilizing the left and right icons.
