### PR TITLE
chore(DS-274): add i18n documentation and AI instruction updates

### DIFF
--- a/agents/AGENTS.md
+++ b/agents/AGENTS.md
@@ -48,9 +48,14 @@ If your application supports multiple languages, override internal component str
 ```tsx
 import { DesignSystemLocaleProvider } from '@worldresources/wri-design-systems'
 
-<DesignSystemLocaleProvider labels={{
-  TextInput: { optionalSuffix: t('common.optional'), requiredSymbolLabel: t('common.required') },
-}}>
+;<DesignSystemLocaleProvider
+  labels={{
+    TextInput: {
+      optionalSuffix: t('common.optional'),
+      requiredSymbolLabel: t('common.required'),
+    },
+  }}
+>
   <App />
 </DesignSystemLocaleProvider>
 ```

--- a/agents/AGENTS.md
+++ b/agents/AGENTS.md
@@ -39,6 +39,24 @@ Key rules (full details in the instructions file):
 5. **No Chakra v2 API** — v3 has breaking changes. Verify props via Chakra MCP.
 6. **Accessibility first** — always provide `aria-*` props (like `aria-label` or `aria-describedby`), explicit `role` attributes, and ensure keyboard focus navigation context when consuming components.
 
+## Internationalization (i18n) — Optional
+
+All WRI DS components ship with English defaults. No i18n setup is needed for English-only apps.
+
+If your application supports multiple languages, override internal component strings by passing pre-translated values via `DesignSystemLocaleProvider` (app-wide) or the component's `labels` prop (per-instance). The library has no runtime i18n dependency — pass strings from your own stack (react-intl, react-i18next, etc.).
+
+```tsx
+import { DesignSystemLocaleProvider } from '@worldresources/wri-design-systems'
+
+<DesignSystemLocaleProvider labels={{
+  TextInput: { optionalSuffix: t('common.optional'), requiredSymbolLabel: t('common.required') },
+}}>
+  <App />
+</DesignSystemLocaleProvider>
+```
+
+Full reference — supported components, label types, and usage patterns: `docs/i18n/README.md`.
+
 ## Design Tokens — Source of Truth
 
 All token functions are imported from the **package**:

--- a/agents/AGENTS.md
+++ b/agents/AGENTS.md
@@ -47,7 +47,6 @@ If your application supports multiple languages, override internal component str
 
 ```tsx
 import { DesignSystemLocaleProvider } from '@worldresources/wri-design-systems'
-
 ;<DesignSystemLocaleProvider
   labels={{
     TextInput: {

--- a/agents/wri-ds.instructions.md
+++ b/agents/wri-ds.instructions.md
@@ -134,6 +134,7 @@ All WRI DS components render English by default — no setup required for Englis
 To provide translated strings, use one of two opt-in approaches:
 
 **Provider** (recommended when multiple components or screens need translations):
+
 ```tsx
 import { DesignSystemLocaleProvider, type DesignSystemLabels } from '@worldresources/wri-design-systems'
 
@@ -145,8 +146,11 @@ const labels: DesignSystemLabels = {
 ```
 
 **Per-component `labels` prop** (for isolated instances):
+
 ```tsx
-<Password labels={{ showLabel: t('password.show'), hideLabel: t('password.hide') }} />
+<Password
+  labels={{ showLabel: t('password.show'), hideLabel: t('password.hide') }}
+/>
 ```
 
 Pass pre-resolved strings only — never hardcoded English literals in `labels` props. Always route through your app's translation function.

--- a/agents/wri-ds.instructions.md
+++ b/agents/wri-ds.instructions.md
@@ -126,3 +126,29 @@ import {
 | Raw token strings: `<Box bg="primary.500" />`                        | `getThemedColor('primary', 500)`                              |
 | Inventing prop names without checking MCP                            | Query Storybook MCP first                                     |
 | Chakra v2 API (`colorScheme`, `variant` on v2 components)            | Verify via Chakra MCP                                         |
+
+## Internationalization (i18n)
+
+All WRI DS components render English by default — no setup required for English-only apps.
+
+To provide translated strings, use one of two opt-in approaches:
+
+**Provider** (recommended when multiple components or screens need translations):
+```tsx
+import { DesignSystemLocaleProvider, type DesignSystemLabels } from '@worldresources/wri-design-systems'
+
+const labels: DesignSystemLabels = {
+  CheckboxList: { expandLabel: t('ds.expand'), hideLabel: t('ds.hide') },
+  TextInput: { optionalSuffix: t('common.optional'), requiredSymbolLabel: t('common.required') },
+}
+<DesignSystemLocaleProvider labels={labels}><App /></DesignSystemLocaleProvider>
+```
+
+**Per-component `labels` prop** (for isolated instances):
+```tsx
+<Password labels={{ showLabel: t('password.show'), hideLabel: t('password.hide') }} />
+```
+
+Pass pre-resolved strings only — never hardcoded English literals in `labels` props. Always route through your app's translation function.
+
+Full reference — all supported components, label types, and patterns: `docs/i18n/README.md`.

--- a/contributor-ai/CONTRIBUTOR.md
+++ b/contributor-ai/CONTRIBUTOR.md
@@ -79,3 +79,7 @@ Accessibility is not optional. Every component must be accessible by default.
 Full rules, per-component type guides, and BAD vs GOOD examples live in `contributor-ai/a11y.instructions.md` — auto-attached by VS Code Copilot whenever you edit `src/components/**`.
 
 Core: define `aria-*` props in `types.ts`, forward them to the DOM, never convey state through color alone, and verify in every story/demo.
+
+## Internationalization (i18n) — Optional
+
+Components ship English defaults — no i18n setup is required for English-only consumers. If a component contains internal strings a consumer might need to translate, expose them via a `labels` prop backed by `useLabels()`. Full procedure in `docs/i18n/README.md` and `contributor-ai/component.instructions.md`.

--- a/contributor-ai/component.instructions.md
+++ b/contributor-ai/component.instructions.md
@@ -14,11 +14,26 @@ applyTo: 'src/components/**'
 5. **Tokens only** — all visual values via `getThemed*` from relative `../../../../lib/theme`. No hardcoded hex/rem/px.
 6. **Element-level check (MANDATORY, repeat for every native element)** — before writing each `<button>`, `<input>`, `<select>`, or `<textarea>`, stop and explicitly ask: "does a WRI DS component cover this element?" The initial check at step 2 is **not sufficient** — every sub-element inside the component being built requires an individual check.
 7. **Accessibility check** — confirm that semantic HTML, `aria-*` props, and keyboard navigation considerations are baked into the component by default.
+8. **Internationalization (optional)** — if the component contains any hardcoded visible or ARIA strings, consider exposing them via a `labels` prop so consumers can translate them. The library ships English defaults; this step is only needed if the component has internal strings. See [Internationalization (i18n)](#internationalization-i18n) below.
 
 ## Accessibility (A11y)
 
 > Full rules are in `contributor-ai/a11y.instructions.md` (auto-attached for `src/components/**`).
 > Key point: always define `aria-*` props in `types.ts`, forward them to the DOM, and verify in your story/demo.
+
+## Internationalization (i18n)
+
+Optional — only relevant when a component contains hardcoded strings. The library always falls back to English defaults, so English-only consumers need no configuration.
+
+If a component has internal strings a consumer might need to translate:
+
+1. Classify each string: **Visual-only** → `ReactNodeLabel`; **A11y-only** (`aria-label`, `placeholder`) → `string`; **Dual-use** or inside a template → `string`; **Interpolated** → `(...args) => string | ReactNode`.
+2. Define `export type XxxLabels = { ... }` in `src/lib/i18n/types.ts` and add `Xxx?: Partial<XxxLabels>` to `DesignSystemLabels`.
+3. Add English defaults to `src/lib/i18n/defaultLabels.ts`.
+4. Add `labels?: Partial<XxxLabels>` to the component's `types.ts` and wire it with `const l = useLabels('Xxx', labels)` at the top of the component.
+5. Export `XxxLabels` from `src/lib/i18n/index.ts` and `src/components/index.ts`.
+
+Full procedure and type classification rules: `docs/i18n/README.md`.
 
 ## Component Hierarchy (never skip a level)
 

--- a/contributor-ai/wri-component-builder.agent.md
+++ b/contributor-ai/wri-component-builder.agent.md
@@ -31,7 +31,8 @@ Before generating a single line of JSX, you MUST execute these steps in order. S
    - Navigation uses `<nav aria-label="...">` and `aria-current="page"` for the active item.
    - Status/alert components have the correct `role` and `aria-live` value.
    - Decorative icons have `aria-hidden="true"`; icon-only interactive parents have `aria-label`.
-9. **Verify** — run `get_errors` on every file touched. Fix all TypeScript errors before responding.
+9. **Internationalization (optional)** — if the component contains any hardcoded visible text or ARIA strings, expose them via a `labels` prop and `useLabels()`. Skip this step if the component has no internal strings. The library always falls back to English defaults — this is opt-in. Full classification and procedure: `docs/i18n/README.md`.
+10. **Verify** — run `get_errors` on every file touched. Fix all TypeScript errors before responding.
 
 If MCP was not queried before implementation, the result is considered incorrect.
 
@@ -226,6 +227,7 @@ Before returning any code, verify each item:
 - [ ] `yarn new-component` was run before any file was created
 - [ ] TypeScript errors checked and resolved
 - [ ] Semantic HTML and accessibility props (`aria-*`, `role`, `tabIndex`) are correctly applied and forwarded
+- [ ] If the component has internal strings: `XxxLabels` type defined, defaults added, `useLabels` wired, type exported (skip if no internal strings)
 
 ---
 

--- a/docs/i18n/README.md
+++ b/docs/i18n/README.md
@@ -1,0 +1,345 @@
+# Internationalization (i18n)
+
+The WRI Design Systems library ships English strings for all internal UI text — `aria-label` values, button text, status messages, and interpolated templates. The i18n layer lets consuming applications override any of these strings without coupling to a specific i18n library.
+
+---
+
+## Contents
+
+1. [How it works](#1-how-it-works)
+2. [File structure](#2-file-structure)
+3. [Public API](#3-public-api)
+4. [Usage](#4-usage)
+   - [App-wide overrides via provider](#41-app-wide-overrides-via-provider)
+   - [Per-component overrides via prop](#42-per-component-overrides-via-prop)
+   - [Mixing both approaches](#43-mixing-both-approaches)
+5. [Label type reference](#5-label-type-reference)
+6. [Case study — GRI Restoration Diagnostic](#6-case-study--gri-restoration-diagnostic)
+
+---
+
+## 1. How it works
+
+Label resolution follows a three-tier priority chain:
+
+```
+defaultLabels (English fallback)
+    ↓
+DesignSystemLocaleProvider (app-wide context)
+    ↓
+labels prop on the component  ← highest priority
+```
+
+The most specific value wins. All keys are optional — any key not provided falls back to the next tier. English-only applications require zero configuration.
+
+> **Note — the implementing application owns all string management.** The design system does not know which language is active, does not load translation files, and does not format or pluralize strings. The consuming application resolves each string to the correct value for the current locale — using whatever mechanism it chooses — and passes the result in.
+>
+> ```tsx
+> // This example uses a simple lookup table; real projects typically use react-intl,
+> // react-i18next, or a custom hook (see the case study in §6).
+> const translations = {
+>   en: { expand: 'Expand', hide: 'Hide' },
+>   es: { expand: 'Expandir', hide: 'Ocultar' },
+>   fr: { expand: 'Développer', hide: 'Masquer' },
+> }
+> const t = translations[activeLocale] // e.g. 'es' → { expand: 'Expandir', hide: 'Ocultar' }
+> 
+> <DesignSystemLocaleProvider
+>   labels={{ CheckboxList: { expandLabel: t.expand, hideLabel: t.hide } }}
+> >
+>   <App />
+> </DesignSystemLocaleProvider>
+> // → CheckboxList renders 'Expandir' / 'Ocultar' when activeLocale is 'es'
+> ```
+
+---
+
+## 2. File structure
+
+```
+src/lib/i18n/
+├── types.ts            # All XxxLabels types + DesignSystemLabels aggregate
+├── defaultLabels.ts    # English fallback values for every migrated component
+├── LocaleProvider.tsx  # DesignSystemLocaleProvider + internal useLocaleContext
+├── useLabels.ts        # Internal hook — 3-tier merge logic
+└── index.ts            # Barrel exports (public API surface)
+```
+
+All exports are re-exported from the package root via `src/components/index.ts`.
+
+---
+
+## 3. Public API
+
+| Export | Kind | Purpose |
+|---|---|---|
+| `DesignSystemLocaleProvider` | Component | Wraps the app root to provide translations to all child components |
+| `DesignSystemLabels` | Type | Type for the `labels` prop on the provider |
+| `CheckboxListLabels`, `PasswordLabels`, `TextInputLabels`, … | Types | Type individual component `labels` props |
+| `defaultLabels` | Object | Reference or extend English defaults |
+
+**Not exported** (internal): `useLabels`, `useLocaleContext`.
+
+---
+
+## 4. Usage
+
+### 4.1 App-wide overrides via provider
+
+**Best for:** applications that use many design system components across multiple pages. A single provider at the app root (or layout level) covers every component in the tree — no repeated prop passing, no per-screen setup. This is the recommended default for any project doing full i18n.
+
+Wrap the app root (or a subtree) with `DesignSystemLocaleProvider` and pass pre-translated strings. The library does not bundle a translation runtime — pass strings produced by your own stack (react-intl, react-i18next, a custom function, etc.).
+
+```tsx
+import {
+  DesignSystemLocaleProvider,
+  type DesignSystemLabels,
+} from '@worldresources/wri-design-systems'
+
+function App({ t }: { t: (key: string) => string }) {
+  const labels: DesignSystemLabels = {
+    CheckboxList: {
+      expandLabel: t('ds.checkboxList.expand'),
+      hideLabel: t('ds.checkboxList.hide'),
+    },
+    TextInput: {
+      requiredSymbolLabel: t('common.required'),
+      optionalSuffix: t('common.optional'),
+    },
+  }
+
+  return (
+    <DesignSystemLocaleProvider labels={labels}>
+      <Routes />
+    </DesignSystemLocaleProvider>
+  )
+}
+```
+
+### 4.2 Per-component overrides via prop
+
+**Best for:** one-off cases — a component used in a single place that needs translated labels, or an instance that requires different text from whatever the provider already supplies. It avoids setting up a provider just for one component, and it lets you override a specific key without touching anything else in the tree.
+
+Every migrated component accepts a `labels` prop typed as `Partial<XxxLabels>`. This is the highest-priority tier and is useful when a single component instance needs different text from the rest of the application.
+
+```tsx
+import { Password, type PasswordLabels } from '@worldresources/wri-design-systems'
+
+function LoginForm({ t }: { t: (key: string) => string }) {
+  const labels: Partial<PasswordLabels> = {
+    showLabel: t('password.show'),
+    hideLabel: t('password.hide'),
+    strengthPrefix: t('password.strengthPrefix'),
+  }
+
+  return <Password label={t('password.label')} labels={labels} required />
+}
+```
+
+### 4.3 Mixing both approaches
+
+**Best for:** when most labels are covered by a root provider but one component instance on a particular screen needs a contextually different string — for example, a `TextInput` that uses "Filter" instead of the globally provided "Search" as its placeholder. The prop override is surgical and does not affect any other instance.
+
+Provider and prop labels can coexist. The prop takes precedence for any key it defines; the provider handles the rest.
+
+```tsx
+<DesignSystemLocaleProvider labels={{ TextInput: { optionalSuffix: t('common.optional') } }}>
+  {/* This instance overrides one additional key at the prop level */}
+  <TextInput
+    label={t('form.name')}
+    labels={{ requiredSymbolLabel: t('form.requiredIndicator') }}
+    required
+  />
+</DesignSystemLocaleProvider>
+```
+
+---
+
+## 5. Label type reference
+
+Each type follows one of four classification rules:
+
+| Category | TypeScript type | Rule |
+|---|---|---|
+| **Visual-only** — rendered as JSX children | `ReactNodeLabel` | Accepts strings, elements, or fragments |
+| **A11y-only** — `aria-label`, `aria-roledescription`, `placeholder` | `string` | HTML spec requires plain strings |
+| **Dual-use** — rendered as text *and* inside an aria template | `string` | The stricter constraint (string) wins |
+| **Interpolated** — contains dynamic values | `(...args) => string \| ReactNode` | Return type follows visual/a11y rule |
+
+**Supported components and their label types:**
+
+| Component | Label type | Keys |
+|---|---|---|
+| `AnalysisWidget` | `AnalysisWidgetLabels` | `toggleSectionLabel` |
+| `BaseMap` | `BaseMapLabels` | `activeLabel` |
+| `Button` | `ButtonLabels` | `loadingLabel` |
+| `CheckboxList` | `CheckboxListLabels` | `expandLabel`, `hideLabel`, `requiredLabel`, `optionalLabel`, `errorPrefix`, `requiredSymbolLabel` |
+| `CloseButton` | `CloseButtonLabels` | `closeLabel` |
+| `InlineMessage` | `InlineMessageLabels` | `roleDescription` |
+| `ItemCount` | `ItemCountLabels` | `perPageLabel`, `showingLabel` |
+| `LayerGroup` | `LayerGroupLabels` | `activeTagLabel`, `groupAriaLabel` |
+| `LegendItem` | `LegendItemLabels` | `dragAndDropLabel`, `upLabel`, `downLabel`, `removeLabel`, `aboutDataLabel` |
+| `MapControlsToolbar` | `MapControlsToolbarLabels` | 15 keys (7 visible labels + 7 aria-labels + 1 toolbar aria-label) |
+| `MapPopUp` | `MapPopUpLabels` | `closeLabel` |
+| `Navbar` | `NavbarLabels` | `openMenuLabel`, `closeLabel`, `menuLabel`, `goBackLabel`, `closeMenuLabel`, `closeButtonText` |
+| `NavigationRail` | `NavigationRailLabels` | `showLabel`, `hideLabel`, `sidebarLabel` |
+| `OpacityControl` | `OpacityControlLabels` | `opacityButtonLabel`, `opacityHeading`, `opacityAriaLabel`, `percentSuffix` |
+| `Pagination` | `PaginationLabels` | `previousLabel`, `nextLabel`, `previousPageLabel`, `nextPageLabel`, `paginationLabel`, `pageLabel` |
+| `Password` | `PasswordLabels` | 17 keys (strength levels, validation rules, show/hide labels) |
+| `QualitativeAttribute` | `QualitativeAttributeLabels` | `hideLabel`, `showLabel`, `visibleText`, `hiddenText`, `linePrefix`, `currentlyTemplate` |
+| `RadioList` | `RadioListLabels` | `requiredLabel`, `optionalLabel`, `errorPrefix`, `requiredSymbolLabel` |
+| `Search` | `SearchLabels` | `filterPlaceholder`, `filterAriaLabel` |
+| `Select` | `SelectLabels` | `defaultAriaLabel`, `requiredSuffix`, `disabledSuffix` |
+| `StepProgressIndicator` | `StepProgressIndicatorLabels` | `currentStepLabel` |
+| `Table` | `TableLabels` | `ascendingLabel`, `descendingLabel` |
+| `Textarea` | `TextareaLabels` | 9 keys (character count messages + required/optional indicators) |
+| `TextInput` | `TextInputLabels` | `requiredSymbolLabel`, `optionalSuffix` |
+| `Toast` | `ToastLabels` | `dismissLabel` |
+| `Toolbar` | `ToolbarLabels` | `collapseLabel`, `expandLabel` |
+
+---
+
+## 6. Case study — GRI Restoration Diagnostic
+
+[GRI Restoration Diagnostic](https://github.com/wri/gri-restoration-diagnostic) is a Next.js 15 application supporting four languages (English, Spanish, French, Portuguese). It uses a custom i18n stack — a `LanguageContext` storing the active locale and a `useTranslations()` hook that returns a `t(key)` function backed by JSON translation files — entirely decoupled from the design system.
+
+**Translation file structure:**
+
+```
+src/i18n/translations/
+├── en.json               # English UI strings (source of truth)
+├── es.json               # Spanish UI strings
+├── fr.json               # French UI strings
+├── pt.json               # Portuguese UI strings
+├── questions-en.json     # Localised question content
+└── questions-es.json
+```
+
+The following examples show the three patterns the project uses to connect its translation layer to the design system's i18n API.
+
+---
+
+### Pattern 1 — Scoped provider for a single component type
+
+The simplest case: a `DesignSystemLocaleProvider` wraps one screen and overrides only the keys needed for the components rendered there.
+
+`src/components/static/landing/OfflineDownloadModal.tsx`
+
+```tsx
+const t = useTranslations()
+
+return (
+  <DesignSystemLocaleProvider
+    labels={{
+      TextInput: {
+        optionalSuffix: t('common.optional'),
+        requiredSymbolLabel: t('common.required'),
+      },
+    }}
+  >
+    <Modal
+      open={open}
+      onClose={handleClose}
+      content={
+        <form>
+          <TextInput
+            label={t('home.cta.offlineModal.labels.name')}
+            placeholder={t('home.cta.offlineModal.placeholders.name')}
+            required
+            {...register('name', rules.name)}
+          />
+          {/* additional fields */}
+        </form>
+      }
+    />
+  </DesignSystemLocaleProvider>
+)
+```
+
+The `t('common.optional')` and `t('common.required')` calls resolve to whatever locale is active at runtime. All `TextInput` components inside the modal receive translated indicator text automatically, with no prop threading required.
+
+---
+
+### Pattern 2 — Provider covering multiple component types
+
+When a screen uses several design system components, a single provider declaration covers all of them.
+
+`src/components/assessment/DiagnosticPreparation/TargetGeography.tsx`
+
+```tsx
+const t = useTranslations()
+
+return (
+  <DesignSystemLocaleProvider
+    labels={{
+      CheckboxList: {
+        errorPrefix:         t('scoping.ecosystems.checkboxListI18nLabels.errorPrefix'),
+        expandLabel:         t('scoping.ecosystems.checkboxListI18nLabels.expandLabel'),
+        hideLabel:           t('scoping.ecosystems.checkboxListI18nLabels.hideLabel'),
+        optionalLabel:       t('scoping.ecosystems.checkboxListI18nLabels.optionalLabel'),
+        requiredLabel:       t('scoping.ecosystems.checkboxListI18nLabels.requiredLabel'),
+        requiredSymbolLabel: t('scoping.ecosystems.checkboxListI18nLabels.requiredSymbolLabel'),
+      },
+      TextInput: {
+        optionalSuffix:      t('common.optional'),
+        requiredSymbolLabel: t('common.required'),
+      },
+    }}
+  >
+    <form>{/* CheckboxList and TextInput fields */}</form>
+  </DesignSystemLocaleProvider>
+)
+```
+
+All six `CheckboxListLabels` keys are overridden using translation keys namespaced to the specific form (`scoping.ecosystems.checkboxListI18nLabels.*`), while the `TextInput` keys reuse shared `common.*` strings already present across the JSON files.
+
+---
+
+### Pattern 3 — Per-component `labels` prop
+
+For the `Password` component — which has 17 label keys covering strength levels, validation rules, and show/hide button text — the project passes all overrides directly on the component instance. This is appropriate when the component appears in a single, isolated location.
+
+`src/components/assessment/PasswordPrompt.tsx`
+
+```tsx
+const t = useTranslations()
+
+<Password
+  label={t('passwordPrompt.passwordLabel')}
+  onChange={handlePasswordChange}
+  hideValidations
+  required
+  labels={{
+    showLabel:          t('passwordPrompt.passwordI18nLabels.showPasswordLabel'),
+    hideLabel:          t('passwordPrompt.passwordI18nLabels.hidePasswordLabel'),
+    showPasswordLabel:  t('passwordPrompt.passwordI18nLabels.showPasswordLabel'),
+    hidePasswordLabel:  t('passwordPrompt.passwordI18nLabels.hidePasswordLabel'),
+    strengthPrefix:     t('passwordPrompt.passwordI18nLabels.strengthPrefix'),
+    strengthVeryWeak:   t('passwordPrompt.passwordI18nLabels.strengthVeryWeak'),
+    strengthWeak:       t('passwordPrompt.passwordI18nLabels.strengthWeak'),
+    strengthMedium:     t('passwordPrompt.passwordI18nLabels.strengthMedium'),
+    strengthStrong:     t('passwordPrompt.passwordI18nLabels.strengthStrong'),
+    strengthVeryStrong: t('passwordPrompt.passwordI18nLabels.strengthVeryStrong'),
+    lowercaseRule:      t('passwordPrompt.passwordI18nLabels.lowercaseRule'),
+    uppercaseRule:      t('passwordPrompt.passwordI18nLabels.uppercaseRule'),
+    numberRule:         t('passwordPrompt.passwordI18nLabels.numberRule'),
+    specialCharRule:    t('passwordPrompt.passwordI18nLabels.specialCharRule'),
+    requirementMet:     t('passwordPrompt.passwordI18nLabels.requirementMet'),
+    requirementNotMet:  t('passwordPrompt.passwordI18nLabels.requirementNotMet'),
+  }}
+/>
+```
+
+The translation keys are grouped under a dedicated `passwordPrompt.passwordI18nLabels` namespace in the JSON files, keeping design system label overrides visually distinct from other application strings.
+
+---
+
+### Pattern summary
+
+| Pattern | When to use |
+|---|---|
+| Provider — single component type | Simple screens or modals with one translated component |
+| Provider — multiple component types | Forms and pages mixing several design system components |
+| Per-component `labels` prop | Isolated instances, or when a component is used in only one place |
+
+All three patterns are compatible with any translation function. The design system requires only pre-resolved strings — it has no dependency on `useTranslations`, `react-intl`, `react-i18next`, or any other runtime.

--- a/docs/i18n/README.md
+++ b/docs/i18n/README.md
@@ -43,7 +43,7 @@ The most specific value wins. All keys are optional — any key not provided fal
 >   fr: { expand: 'Développer', hide: 'Masquer' },
 > }
 > const t = translations[activeLocale] // e.g. 'es' → { expand: 'Expandir', hide: 'Ocultar' }
-> 
+>
 > <DesignSystemLocaleProvider
 >   labels={{ CheckboxList: { expandLabel: t.expand, hideLabel: t.hide } }}
 > >
@@ -71,12 +71,12 @@ All exports are re-exported from the package root via `src/components/index.ts`.
 
 ## 3. Public API
 
-| Export | Kind | Purpose |
-|---|---|---|
-| `DesignSystemLocaleProvider` | Component | Wraps the app root to provide translations to all child components |
-| `DesignSystemLabels` | Type | Type for the `labels` prop on the provider |
-| `CheckboxListLabels`, `PasswordLabels`, `TextInputLabels`, … | Types | Type individual component `labels` props |
-| `defaultLabels` | Object | Reference or extend English defaults |
+| Export                                                       | Kind      | Purpose                                                            |
+| ------------------------------------------------------------ | --------- | ------------------------------------------------------------------ |
+| `DesignSystemLocaleProvider`                                 | Component | Wraps the app root to provide translations to all child components |
+| `DesignSystemLabels`                                         | Type      | Type for the `labels` prop on the provider                         |
+| `CheckboxListLabels`, `PasswordLabels`, `TextInputLabels`, … | Types     | Type individual component `labels` props                           |
+| `defaultLabels`                                              | Object    | Reference or extend English defaults                               |
 
 **Not exported** (internal): `useLabels`, `useLocaleContext`.
 
@@ -123,7 +123,10 @@ function App({ t }: { t: (key: string) => string }) {
 Every migrated component accepts a `labels` prop typed as `Partial<XxxLabels>`. This is the highest-priority tier and is useful when a single component instance needs different text from the rest of the application.
 
 ```tsx
-import { Password, type PasswordLabels } from '@worldresources/wri-design-systems'
+import {
+  Password,
+  type PasswordLabels,
+} from '@worldresources/wri-design-systems'
 
 function LoginForm({ t }: { t: (key: string) => string }) {
   const labels: Partial<PasswordLabels> = {
@@ -143,7 +146,9 @@ function LoginForm({ t }: { t: (key: string) => string }) {
 Provider and prop labels can coexist. The prop takes precedence for any key it defines; the provider handles the rest.
 
 ```tsx
-<DesignSystemLocaleProvider labels={{ TextInput: { optionalSuffix: t('common.optional') } }}>
+<DesignSystemLocaleProvider
+  labels={{ TextInput: { optionalSuffix: t('common.optional') } }}
+>
   {/* This instance overrides one additional key at the prop level */}
   <TextInput
     label={t('form.name')}
@@ -159,43 +164,43 @@ Provider and prop labels can coexist. The prop takes precedence for any key it d
 
 Each type follows one of four classification rules:
 
-| Category | TypeScript type | Rule |
-|---|---|---|
-| **Visual-only** — rendered as JSX children | `ReactNodeLabel` | Accepts strings, elements, or fragments |
-| **A11y-only** — `aria-label`, `aria-roledescription`, `placeholder` | `string` | HTML spec requires plain strings |
-| **Dual-use** — rendered as text *and* inside an aria template | `string` | The stricter constraint (string) wins |
-| **Interpolated** — contains dynamic values | `(...args) => string \| ReactNode` | Return type follows visual/a11y rule |
+| Category                                                            | TypeScript type                    | Rule                                    |
+| ------------------------------------------------------------------- | ---------------------------------- | --------------------------------------- |
+| **Visual-only** — rendered as JSX children                          | `ReactNodeLabel`                   | Accepts strings, elements, or fragments |
+| **A11y-only** — `aria-label`, `aria-roledescription`, `placeholder` | `string`                           | HTML spec requires plain strings        |
+| **Dual-use** — rendered as text _and_ inside an aria template       | `string`                           | The stricter constraint (string) wins   |
+| **Interpolated** — contains dynamic values                          | `(...args) => string \| ReactNode` | Return type follows visual/a11y rule    |
 
 **Supported components and their label types:**
 
-| Component | Label type | Keys |
-|---|---|---|
-| `AnalysisWidget` | `AnalysisWidgetLabels` | `toggleSectionLabel` |
-| `BaseMap` | `BaseMapLabels` | `activeLabel` |
-| `Button` | `ButtonLabels` | `loadingLabel` |
-| `CheckboxList` | `CheckboxListLabels` | `expandLabel`, `hideLabel`, `requiredLabel`, `optionalLabel`, `errorPrefix`, `requiredSymbolLabel` |
-| `CloseButton` | `CloseButtonLabels` | `closeLabel` |
-| `InlineMessage` | `InlineMessageLabels` | `roleDescription` |
-| `ItemCount` | `ItemCountLabels` | `perPageLabel`, `showingLabel` |
-| `LayerGroup` | `LayerGroupLabels` | `activeTagLabel`, `groupAriaLabel` |
-| `LegendItem` | `LegendItemLabels` | `dragAndDropLabel`, `upLabel`, `downLabel`, `removeLabel`, `aboutDataLabel` |
-| `MapControlsToolbar` | `MapControlsToolbarLabels` | 15 keys (7 visible labels + 7 aria-labels + 1 toolbar aria-label) |
-| `MapPopUp` | `MapPopUpLabels` | `closeLabel` |
-| `Navbar` | `NavbarLabels` | `openMenuLabel`, `closeLabel`, `menuLabel`, `goBackLabel`, `closeMenuLabel`, `closeButtonText` |
-| `NavigationRail` | `NavigationRailLabels` | `showLabel`, `hideLabel`, `sidebarLabel` |
-| `OpacityControl` | `OpacityControlLabels` | `opacityButtonLabel`, `opacityHeading`, `opacityAriaLabel`, `percentSuffix` |
-| `Pagination` | `PaginationLabels` | `previousLabel`, `nextLabel`, `previousPageLabel`, `nextPageLabel`, `paginationLabel`, `pageLabel` |
-| `Password` | `PasswordLabels` | 17 keys (strength levels, validation rules, show/hide labels) |
-| `QualitativeAttribute` | `QualitativeAttributeLabels` | `hideLabel`, `showLabel`, `visibleText`, `hiddenText`, `linePrefix`, `currentlyTemplate` |
-| `RadioList` | `RadioListLabels` | `requiredLabel`, `optionalLabel`, `errorPrefix`, `requiredSymbolLabel` |
-| `Search` | `SearchLabels` | `filterPlaceholder`, `filterAriaLabel` |
-| `Select` | `SelectLabels` | `defaultAriaLabel`, `requiredSuffix`, `disabledSuffix` |
-| `StepProgressIndicator` | `StepProgressIndicatorLabels` | `currentStepLabel` |
-| `Table` | `TableLabels` | `ascendingLabel`, `descendingLabel` |
-| `Textarea` | `TextareaLabels` | 9 keys (character count messages + required/optional indicators) |
-| `TextInput` | `TextInputLabels` | `requiredSymbolLabel`, `optionalSuffix` |
-| `Toast` | `ToastLabels` | `dismissLabel` |
-| `Toolbar` | `ToolbarLabels` | `collapseLabel`, `expandLabel` |
+| Component               | Label type                    | Keys                                                                                               |
+| ----------------------- | ----------------------------- | -------------------------------------------------------------------------------------------------- |
+| `AnalysisWidget`        | `AnalysisWidgetLabels`        | `toggleSectionLabel`                                                                               |
+| `BaseMap`               | `BaseMapLabels`               | `activeLabel`                                                                                      |
+| `Button`                | `ButtonLabels`                | `loadingLabel`                                                                                     |
+| `CheckboxList`          | `CheckboxListLabels`          | `expandLabel`, `hideLabel`, `requiredLabel`, `optionalLabel`, `errorPrefix`, `requiredSymbolLabel` |
+| `CloseButton`           | `CloseButtonLabels`           | `closeLabel`                                                                                       |
+| `InlineMessage`         | `InlineMessageLabels`         | `roleDescription`                                                                                  |
+| `ItemCount`             | `ItemCountLabels`             | `perPageLabel`, `showingLabel`                                                                     |
+| `LayerGroup`            | `LayerGroupLabels`            | `activeTagLabel`, `groupAriaLabel`                                                                 |
+| `LegendItem`            | `LegendItemLabels`            | `dragAndDropLabel`, `upLabel`, `downLabel`, `removeLabel`, `aboutDataLabel`                        |
+| `MapControlsToolbar`    | `MapControlsToolbarLabels`    | 15 keys (7 visible labels + 7 aria-labels + 1 toolbar aria-label)                                  |
+| `MapPopUp`              | `MapPopUpLabels`              | `closeLabel`                                                                                       |
+| `Navbar`                | `NavbarLabels`                | `openMenuLabel`, `closeLabel`, `menuLabel`, `goBackLabel`, `closeMenuLabel`, `closeButtonText`     |
+| `NavigationRail`        | `NavigationRailLabels`        | `showLabel`, `hideLabel`, `sidebarLabel`                                                           |
+| `OpacityControl`        | `OpacityControlLabels`        | `opacityButtonLabel`, `opacityHeading`, `opacityAriaLabel`, `percentSuffix`                        |
+| `Pagination`            | `PaginationLabels`            | `previousLabel`, `nextLabel`, `previousPageLabel`, `nextPageLabel`, `paginationLabel`, `pageLabel` |
+| `Password`              | `PasswordLabels`              | 17 keys (strength levels, validation rules, show/hide labels)                                      |
+| `QualitativeAttribute`  | `QualitativeAttributeLabels`  | `hideLabel`, `showLabel`, `visibleText`, `hiddenText`, `linePrefix`, `currentlyTemplate`           |
+| `RadioList`             | `RadioListLabels`             | `requiredLabel`, `optionalLabel`, `errorPrefix`, `requiredSymbolLabel`                             |
+| `Search`                | `SearchLabels`                | `filterPlaceholder`, `filterAriaLabel`                                                             |
+| `Select`                | `SelectLabels`                | `defaultAriaLabel`, `requiredSuffix`, `disabledSuffix`                                             |
+| `StepProgressIndicator` | `StepProgressIndicatorLabels` | `currentStepLabel`                                                                                 |
+| `Table`                 | `TableLabels`                 | `ascendingLabel`, `descendingLabel`                                                                |
+| `Textarea`              | `TextareaLabels`              | 9 keys (character count messages + required/optional indicators)                                   |
+| `TextInput`             | `TextInputLabels`             | `requiredSymbolLabel`, `optionalSuffix`                                                            |
+| `Toast`                 | `ToastLabels`                 | `dismissLabel`                                                                                     |
+| `Toolbar`               | `ToolbarLabels`               | `collapseLabel`, `expandLabel`                                                                     |
 
 ---
 
@@ -273,15 +278,21 @@ return (
   <DesignSystemLocaleProvider
     labels={{
       CheckboxList: {
-        errorPrefix:         t('scoping.ecosystems.checkboxListI18nLabels.errorPrefix'),
-        expandLabel:         t('scoping.ecosystems.checkboxListI18nLabels.expandLabel'),
-        hideLabel:           t('scoping.ecosystems.checkboxListI18nLabels.hideLabel'),
-        optionalLabel:       t('scoping.ecosystems.checkboxListI18nLabels.optionalLabel'),
-        requiredLabel:       t('scoping.ecosystems.checkboxListI18nLabels.requiredLabel'),
-        requiredSymbolLabel: t('scoping.ecosystems.checkboxListI18nLabels.requiredSymbolLabel'),
+        errorPrefix: t('scoping.ecosystems.checkboxListI18nLabels.errorPrefix'),
+        expandLabel: t('scoping.ecosystems.checkboxListI18nLabels.expandLabel'),
+        hideLabel: t('scoping.ecosystems.checkboxListI18nLabels.hideLabel'),
+        optionalLabel: t(
+          'scoping.ecosystems.checkboxListI18nLabels.optionalLabel',
+        ),
+        requiredLabel: t(
+          'scoping.ecosystems.checkboxListI18nLabels.requiredLabel',
+        ),
+        requiredSymbolLabel: t(
+          'scoping.ecosystems.checkboxListI18nLabels.requiredSymbolLabel',
+        ),
       },
       TextInput: {
-        optionalSuffix:      t('common.optional'),
+        optionalSuffix: t('common.optional'),
         requiredSymbolLabel: t('common.required'),
       },
     }}
@@ -336,10 +347,10 @@ The translation keys are grouped under a dedicated `passwordPrompt.passwordI18nL
 
 ### Pattern summary
 
-| Pattern | When to use |
-|---|---|
-| Provider — single component type | Simple screens or modals with one translated component |
-| Provider — multiple component types | Forms and pages mixing several design system components |
-| Per-component `labels` prop | Isolated instances, or when a component is used in only one place |
+| Pattern                             | When to use                                                       |
+| ----------------------------------- | ----------------------------------------------------------------- |
+| Provider — single component type    | Simple screens or modals with one translated component            |
+| Provider — multiple component types | Forms and pages mixing several design system components           |
+| Per-component `labels` prop         | Isolated instances, or when a component is used in only one place |
 
 All three patterns are compatible with any translation function. The design system requires only pre-resolved strings — it has no dependency on `useTranslations`, `react-intl`, `react-i18next`, or any other runtime.

--- a/i18n-rollout.md
+++ b/i18n-rollout.md
@@ -1,0 +1,1017 @@
+# i18n Low-Level Design — WRI Design Systems
+
+> **Status:** Phases 1 & 2 complete (branch `DS-273`). Phase 3 in progress (branch `DS-274`).
+> **Last updated:** April 9, 2026
+
+---
+
+## Table of Contents
+
+1. [Overview](#1-overview)
+2. [Architecture](#2-architecture)
+3. [Implemented Infrastructure](#3-implemented-infrastructure)
+4. [Label Type Classification](#4-label-type-classification)
+5. [Migration Procedure](#5-migration-procedure)
+6. [Task Definitions — Phase 3](#6-task-definitions--phase-3)
+7. [Task Definitions — Phase 4](#7-task-definitions--phase-4)
+8. [Progress Tracker](#8-progress-tracker)
+9. [Appendix](#9-appendix)
+
+---
+
+## 1. Overview
+
+### 1.1 Problem
+
+The `@worldresources/wri-design-systems` library contains ~80+ hardcoded English strings across 26 components — `aria-label` values, button text, status messages, and interpolated templates. Consumers building multilingual applications cannot translate these internal strings.
+
+### 1.2 Solution
+
+A **library-agnostic, props-based i18n layer** that:
+
+- Exposes an optional `labels?: Partial<XxxLabels>` prop on every component with internal strings.
+- Provides a `DesignSystemLocaleProvider` context for app-wide label overrides.
+- Ships English defaults — zero config needed for English-only apps.
+- **No runtime i18n library dependency.** Consumers pre-translate strings with their own solution (react-intl, react-i18next, custom) and pass them in.
+
+### 1.3 Design Principles
+
+| Principle                 | Detail                                                                                          |
+| ------------------------- | ----------------------------------------------------------------------------------------------- |
+| **Zero breaking changes** | All labels are optional with English defaults. Existing consumers are unaffected.               |
+| **Type safety**           | Every label key is typed — `string` for a11y attributes, `ReactNodeLabel` for visual-only text. |
+| **3-tier resolution**     | Component prop → context → default. Most specific wins.                                         |
+| **No i18n runtime**       | We don't bundle react-intl, FormatJS, or any ICU runtime. Consumers own their i18n stack.       |
+| **Incremental rollout**   | Components are migrated individually; each migration is a self-contained, reviewable unit.      |
+
+### 1.4 Scope
+
+| In Scope                                                       | Out of Scope                                                                            |
+| -------------------------------------------------------------- | --------------------------------------------------------------------------------------- |
+| All hardcoded strings in 26 components                         | RTL layout (handled by CSS, not this system)                                            |
+| `aria-label`, `aria-roledescription`, `placeholder` attributes | Date/number formatting (consumer responsibility)                                        |
+| Visible button text, status messages, headings                 | Pluralization rules (consumers use their own ICU lib)                                   |
+| Interpolated templates (character counts, pagination)          | Component prop labels (e.g., `<TextInput label="Email">`) — already consumer-controlled |
+
+---
+
+## 2. Architecture
+
+### 2.1 File Structure
+
+```
+src/lib/i18n/
+├── types.ts            # All XxxLabels types + DesignSystemLabels aggregate + ReactNodeLabel alias
+├── defaultLabels.ts    # English fallback values (one entry per migrated component)
+├── LocaleProvider.tsx  # React context provider + internal useLocaleContext hook
+├── useLabels.ts        # Internal hook — 3-tier merge logic
+└── index.ts            # Barrel exports (public API surface)
+```
+
+### 2.2 Resolution Flow
+
+```
+┌──────────────────────────────────────────────────────────────┐
+│                     Component Render                         │
+│                                                              │
+│  const l = useLabels('ComponentName', props.labels)          │
+│                                                              │
+│  ┌─────────────────────────────────────────────────────────┐ │
+│  │                  useLabels() merge                      │ │
+│  │                                                         │ │
+│  │   defaultLabels['ComponentName']     ← lowest priority  │ │
+│  │       ↓ spread                                          │ │
+│  │   contextLabels['ComponentName']     ← from Provider    │ │
+│  │       ↓ spread                                          │ │
+│  │   propsLabels                        ← highest priority │ │
+│  │       ↓                                                 │ │
+│  │   return merged object (fully resolved, all keys set)   │ │
+│  └─────────────────────────────────────────────────────────┘ │
+│                                                              │
+│  l.expandLabel  ← guaranteed defined, safe to use directly   │
+└──────────────────────────────────────────────────────────────┘
+```
+
+### 2.3 Public API Surface
+
+Exported from `src/components/index.ts`:
+
+| Export                                                    | Kind      | Consumer Use                                            |
+| --------------------------------------------------------- | --------- | ------------------------------------------------------- |
+| `DesignSystemLocaleProvider`                              | Component | Wrap app root to provide translations to all components |
+| `DesignSystemLabels`                                      | Type      | Type the `labels` prop on the provider                  |
+| `CheckboxListLabels`, `PasswordLabels`, `TextInputLabels` | Types     | Type individual component `labels` props                |
+| `defaultLabels`                                           | Object    | Reference or extend English defaults                    |
+
+**Not exported** (internal only): `useLabels`, `useLocaleContext`.
+
+### 2.4 Consumer Integration Example
+
+```tsx
+import { useIntl } from 'react-intl'
+import {
+  DesignSystemLocaleProvider,
+  DesignSystemLabels,
+} from '@worldresources/wri-design-systems'
+
+function App() {
+  const intl = useIntl()
+  const labels: DesignSystemLabels = {
+    CheckboxList: {
+      expandLabel: intl.formatMessage({ id: 'ds.checkboxList.expand' }),
+      hideLabel: intl.formatMessage({ id: 'ds.checkboxList.hide' }),
+    },
+    Password: {
+      strengthPrefix: intl.formatMessage({ id: 'ds.password.strengthPrefix' }),
+      minLengthRule: (min) =>
+        intl.formatMessage({ id: 'ds.password.minLength' }, { min }),
+    },
+  }
+  return (
+    <DesignSystemLocaleProvider labels={labels}>
+      <Routes />
+    </DesignSystemLocaleProvider>
+  )
+}
+```
+
+---
+
+## 3. Implemented Infrastructure
+
+### 3.1 Current State (as of April 9, 2026)
+
+| File                              | Status | Content                                                                                                                                   |
+| --------------------------------- | ------ | ----------------------------------------------------------------------------------------------------------------------------------------- |
+| `src/lib/i18n/types.ts`           | ✅     | `ReactNodeLabel`, `CheckboxListLabels` (6 keys), `PasswordLabels` (17 keys), `TextInputLabels` (2 keys), `DesignSystemLabels` (3 entries) |
+| `src/lib/i18n/defaultLabels.ts`   | ✅     | English defaults for 3 components. `DefaultLabels` type derived from `Required<XxxLabels>`                                                |
+| `src/lib/i18n/LocaleProvider.tsx` | ✅     | `DesignSystemLocaleProvider` with `useMemo`. Internal `useLocaleContext`                                                                  |
+| `src/lib/i18n/useLabels.ts`       | ✅     | Generic hook constrained to `keyof typeof defaultLabels`                                                                                  |
+| `src/lib/i18n/index.ts`           | ✅     | Barrel re-exports                                                                                                                         |
+| `src/components/index.ts`         | ✅     | Exports provider + all label types                                                                                                        |
+
+### 3.2 Migrated Components
+
+| Component      | Branch   | Label Keys                                       | Stories                             | README          |
+| -------------- | -------- | ------------------------------------------------ | ----------------------------------- | --------------- |
+| `CheckboxList` | `DS-273` | 6 (2 `ReactNodeLabel`, 4 `string`)               | `WithI18nLabels`, `WithI18nContext` | ✅ i18n section |
+| `Password`     | `DS-273` | 17 (6 `ReactNodeLabel`, 10 `string`, 1 function) | `WithI18nLabels`, `WithI18nContext` | ✅ i18n section |
+| `TextInput`    | `DS-273` | 2 (1 `ReactNodeLabel`, 1 `string`)               | `WithI18nLabels`, `WithI18nContext` | ✅ i18n section |
+
+---
+
+## 4. Label Type Classification
+
+Every key in a `XxxLabels` type **must** be classified by its actual usage in the component source:
+
+| Category                                                                      | TypeScript Type                                   | Rule                                                     | Examples                                                           |
+| ----------------------------------------------------------------------------- | ------------------------------------------------- | -------------------------------------------------------- | ------------------------------------------------------------------ |
+| **Visual-only** — rendered as JSX children                                    | `ReactNodeLabel`                                  | Accepts strings, elements, fragments                     | Button text, visible headings, status text in `<p>`                |
+| **A11y-only** — passed to `aria-label`, `aria-roledescription`, `placeholder` | `string`                                          | HTML spec requires plain strings for `aria-*`            | `aria-label="Close"`, `placeholder="Filter"`                       |
+| **Dual-use** — both JSX child AND inside an aria template                     | `string`                                          | Stricter constraint wins                                 | Password rules (rendered in `<p>` + used in `aria-label` template) |
+| **Interpolated** — contains dynamic values                                    | `(...args) => string` or `(...args) => ReactNode` | Function signature; return type follows visual/a11y rule | `(min) => "Use a minimum of ${min} chars"`                         |
+
+### Constraint: Button.label prop
+
+The existing `Button` component types `label` as `string`. Until that is widened to `ReactNode`, any label key whose value flows into `<Button label={...}>` **must** be typed as `string`, not `ReactNodeLabel`.
+
+Affected keys: `OpacityControlLabels.opacityButtonLabel`, `PasswordLabels.showLabel`, `PasswordLabels.hideLabel`.
+
+---
+
+## 5. Migration Procedure
+
+Each component migration is a self-contained unit. Follow this checklist:
+
+### 5.1 Pre-Implementation
+
+- [ ] Read the component source and identify every hardcoded string
+- [ ] Classify each string (Visual / A11y / Dual-use / Interpolated)
+- [ ] Check if the component passes strings to sub-components (e.g., `Button.label`) — those constrain the type
+
+### 5.2 Implementation Steps
+
+| Step                         | File(s) to modify                                   | Action                                                                           |
+| ---------------------------- | --------------------------------------------------- | -------------------------------------------------------------------------------- |
+| **1. Define types**          | `src/lib/i18n/types.ts`                             | Add `export type XxxLabels = { ... }` with classified keys                       |
+| **2. Register in aggregate** | `src/lib/i18n/types.ts`                             | Add `Xxx?: Partial<XxxLabels>` to `DesignSystemLabels`                           |
+| **3. Add defaults**          | `src/lib/i18n/defaultLabels.ts`                     | Add component key to `defaultLabels` object and `DefaultLabels` type             |
+| **4. Add labels prop**       | `src/components/.../types.ts`                       | Add `labels?: Partial<XxxLabels>` to `XxxProps`. Re-export label type.           |
+| **5. Wire useLabels**        | `src/components/.../index.tsx`                      | `const l = useLabels('Xxx', labels)` at top of component                         |
+| **6. Replace strings**       | `src/components/.../index.tsx`                      | Replace each hardcoded string with `l.keyName`                                   |
+| **7. Add i18n story**        | `src/components/.../Xxx.stories.tsx`                | Add `WithI18nLabels` (prop-level) and `WithI18nContext` (provider-level) stories |
+| **8. Update README**         | `src/components/.../README.md`                      | Add `## Internationalization (i18n)` section with labels table                   |
+| **9. Export type**           | `src/lib/i18n/index.ts` + `src/components/index.ts` | Add `XxxLabels` to barrel exports                                                |
+| **10. Verify**               | Terminal                                            | `npx tsc --noEmit` — zero errors                                                 |
+
+### 5.3 Post-Implementation Verification
+
+- [ ] `npx tsc --noEmit` passes
+- [ ] Storybook renders default (English) story unchanged
+- [ ] `WithI18nLabels` story shows overridden labels
+- [ ] `WithI18nContext` story shows context-provided labels
+- [ ] Component `labels` prop is optional — omitting it renders English defaults
+
+---
+
+## 6. Task Definitions — Phase 3
+
+### Legend
+
+- **Complexity:** A (1–2 strings), B (3–5 strings), C (6+ strings or interpolation)
+- **Dependencies:** Unless noted, all tasks depend only on the existing i18n infrastructure (Phase 1–2). Tasks within a tier are independent and can be parallelized.
+- **Files touched per task:** `types.ts` (i18n), `defaultLabels.ts`, component `types.ts`, component `index.tsx`, component `.stories.tsx`, component `README.md`, `i18n/index.ts`, `components/index.ts`
+
+---
+
+### 6.1 Tier A — Simple Components (9 tasks, ~11 label keys)
+
+Each Tier A task follows the same minimal pattern: one type with 1–2 `string` keys (mostly aria-labels).
+
+---
+
+#### TASK A-1: CloseButton
+
+| Field                 | Value                                                                                                                                       |
+| --------------------- | ------------------------------------------------------------------------------------------------------------------------------------------- |
+| **File**              | `src/components/Forms/Actions/CloseButton/index.tsx`                                                                                        |
+| **Hardcoded strings** | `'Close'` → `aria-label` fallback                                                                                                           |
+| **Label type**        | `CloseButtonLabels = { closeLabel: string }`                                                                                                |
+| **Default**           | `closeLabel: 'Close'`                                                                                                                       |
+| **Classification**    | A11y-only (aria-label)                                                                                                                      |
+| **Notes**             | Only applies when no `aria-label` is provided via props. Check if component spreads `...rest` that may include consumer's own `aria-label`. |
+
+---
+
+#### TASK A-2: Toast
+
+| Field                 | Value                                                                  |
+| --------------------- | ---------------------------------------------------------------------- |
+| **File**              | `src/components/Status/Toast/index.tsx`                                |
+| **Hardcoded strings** | `'Dismiss'` → dismiss button `aria-label`                              |
+| **Label type**        | `ToastLabels = { dismissLabel: string }`                               |
+| **Default**           | `dismissLabel: 'Dismiss'`                                              |
+| **Classification**    | A11y-only                                                              |
+| **Notes**             | Toast may also use `showToast()` utility — verify labels flow through. |
+
+---
+
+#### TASK A-3: InlineMessage
+
+| Field                 | Value                                               |
+| --------------------- | --------------------------------------------------- |
+| **File**              | `src/components/Status/InlineMessage/index.tsx`     |
+| **Hardcoded strings** | `'Note'` → `aria-roledescription`                   |
+| **Label type**        | `InlineMessageLabels = { roleDescription: string }` |
+| **Default**           | `roleDescription: 'Note'`                           |
+| **Classification**    | A11y-only (aria-roledescription)                    |
+
+---
+
+#### TASK A-4: MapPopUp
+
+| Field                 | Value                                          |
+| --------------------- | ---------------------------------------------- |
+| **File**              | `src/components/Geospatial/MapPopUp/index.tsx` |
+| **Hardcoded strings** | `'Close'` → close button `aria-label`          |
+| **Label type**        | `MapPopUpLabels = { closeLabel: string }`      |
+| **Default**           | `closeLabel: 'Close'`                          |
+| **Classification**    | A11y-only                                      |
+
+---
+
+#### TASK A-5: AnalysisWidget
+
+| Field                 | Value                                                   |
+| --------------------- | ------------------------------------------------------- |
+| **File**              | `src/components/DataDisplay/AnalysisWidget/index.tsx`   |
+| **Hardcoded strings** | `'Toggle section'` → collapsible trigger `aria-label`   |
+| **Label type**        | `AnalysisWidgetLabels = { toggleSectionLabel: string }` |
+| **Default**           | `toggleSectionLabel: 'Toggle section'`                  |
+| **Classification**    | A11y-only                                               |
+
+---
+
+#### TASK A-6: Table
+
+| Field                 | Value                                                               |
+| --------------------- | ------------------------------------------------------------------- |
+| **File**              | `src/components/DataDisplay/Table/index.tsx`                        |
+| **Hardcoded strings** | `'Ascending'`, `'Descending'` → sort icon `aria-label`s             |
+| **Label type**        | `TableLabels = { ascendingLabel: string; descendingLabel: string }` |
+| **Defaults**          | `ascendingLabel: 'Ascending'`, `descendingLabel: 'Descending'`      |
+| **Classification**    | A11y-only                                                           |
+
+---
+
+#### TASK A-7: Button
+
+| Field                 | Value                                                   |
+| --------------------- | ------------------------------------------------------- |
+| **File**              | `src/components/Forms/Actions/Button/index.tsx`         |
+| **Hardcoded strings** | `'Loading'` → `aria-label` applied during loading state |
+| **Label type**        | `ButtonLabels = { loadingLabel: string }`               |
+| **Default**           | `loadingLabel: 'Loading'`                               |
+| **Classification**    | A11y-only                                               |
+| **Notes**             | Ensure loading state detection logic is not affected.   |
+
+---
+
+#### TASK A-8: BaseMap
+
+| Field                 | Value                                             |
+| --------------------- | ------------------------------------------------- |
+| **File**              | `src/components/Geospatial/BaseMap/index.tsx`     |
+| **Hardcoded strings** | `'Active'` → visible Tag label text               |
+| **Label type**        | `BaseMapLabels = { activeLabel: ReactNodeLabel }` |
+| **Default**           | `activeLabel: 'Active'`                           |
+| **Classification**    | Visual-only (JSX child in `<Tag>`)                |
+
+---
+
+#### TASK A-9: Search
+
+| Field                 | Value                                                                      |
+| --------------------- | -------------------------------------------------------------------------- |
+| **File**              | `src/components/Navigation/Search/index.tsx`                               |
+| **Hardcoded strings** | `'Filter'` → `placeholder`, `'Search filter'` → `aria-label`               |
+| **Label type**        | `SearchLabels = { filterPlaceholder: string; filterAriaLabel: string }`    |
+| **Defaults**          | `filterPlaceholder: 'Filter'`, `filterAriaLabel: 'Search filter'`          |
+| **Classification**    | Both A11y-only (placeholder is a string attribute, aria-label is a string) |
+
+---
+
+#### Tier A — Aggregate Type Definitions
+
+```ts
+export type CloseButtonLabels = { closeLabel: string }
+export type ToastLabels = { dismissLabel: string }
+export type InlineMessageLabels = { roleDescription: string }
+export type MapPopUpLabels = { closeLabel: string }
+export type AnalysisWidgetLabels = { toggleSectionLabel: string }
+export type TableLabels = { ascendingLabel: string; descendingLabel: string }
+export type ButtonLabels = { loadingLabel: string }
+export type BaseMapLabels = { activeLabel: ReactNodeLabel }
+export type SearchLabels = {
+  filterPlaceholder: string
+  filterAriaLabel: string
+}
+```
+
+---
+
+### 6.2 Tier B — Medium Components (7 tasks, ~27 label keys)
+
+---
+
+#### TASK B-1: RadioList
+
+| Field                 | Value                                                                                                                                                  |
+| --------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| **File**              | `src/components/Forms/Inputs/RadioList/index.tsx`                                                                                                      |
+| **Hardcoded strings** | `'Required.'` (aria-label suffix), `'Optional.'` (aria-label suffix), `'Error: ...'` (aria-label prefix), `'required'` (`aria-label` on `*` indicator) |
+| **Classification**    | All A11y-only — used in `aria-label` template construction                                                                                             |
+| **Notes**             | Same pattern as CheckboxList. Shares `requiredSymbolLabel` / `errorPrefix` key names for consistency.                                                  |
+
+```ts
+export type RadioListLabels = {
+  requiredLabel: string // " Required." appended to aria-label
+  optionalLabel: string // " Optional." appended to aria-label
+  errorPrefix: string // "Error: " prepended to error in aria-label
+  requiredSymbolLabel: string // aria-label on the (*) indicator
+}
+```
+
+**Defaults:** `{ requiredLabel: 'Required.', optionalLabel: 'Optional.', errorPrefix: 'Error:', requiredSymbolLabel: 'required' }`
+
+---
+
+#### TASK B-2: Select
+
+| Field                 | Value                                                                                         |
+| --------------------- | --------------------------------------------------------------------------------------------- |
+| **File**              | `src/components/Forms/Inputs/Select/index.tsx`                                                |
+| **Hardcoded strings** | `'Select input'` (default `aria-label`), `' required.'` (appended), `' Disabled.'` (appended) |
+| **Classification**    | All A11y-only                                                                                 |
+
+```ts
+export type SelectLabels = {
+  defaultAriaLabel: string // fallback aria-label when no label prop
+  requiredSuffix: string // " required." appended to aria-label
+  disabledSuffix: string // " Disabled." appended to aria-label
+}
+```
+
+**Defaults:** `{ defaultAriaLabel: 'Select input', requiredSuffix: ' required.', disabledSuffix: ' Disabled.' }`
+
+---
+
+#### TASK B-3: NavigationRail
+
+| Field                 | Value                                                                      |
+| --------------------- | -------------------------------------------------------------------------- |
+| **File**              | `src/components/Navigation/NavigationRail/index.tsx`                       |
+| **Hardcoded strings** | `'Show'` (button text), `'Hide'` (button text), `'Sidebar'` (visible text) |
+| **Classification**    | All Visual-only (JSX children)                                             |
+
+```ts
+export type NavigationRailLabels = {
+  showLabel: ReactNodeLabel // visible toggle button text
+  hideLabel: ReactNodeLabel // visible toggle button text
+  sidebarLabel: ReactNodeLabel // visible heading/text
+}
+```
+
+**Defaults:** `{ showLabel: 'Show', hideLabel: 'Hide', sidebarLabel: 'Sidebar' }`
+
+---
+
+#### TASK B-4: Navbar
+
+| Field                 | Value                                                                                                                                                                                                                                        |
+| --------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Files**             | `src/components/Navigation/Navbar/index.tsx`, `NavbarMobile.tsx`                                                                                                                                                                             |
+| **Hardcoded strings** | `'Open menu'` (aria-label, desktop), `'Close'` (visible text, desktop toggle), `'Menu'` (visible text, desktop toggle), `'Go back'` (aria-label, mobile), `'Close menu'` (aria-label, mobile), `'Close'` (visible text, mobile close button) |
+| **Classification**    | Mixed — see per-key comments                                                                                                                                                                                                                 |
+| **Notes**             | Spans two files. `Navbar/index.tsx` must pass resolved labels down to `NavbarMobile` via props. `NavbarMobile` should **not** call `useLabels` independently — it receives the resolved labels subset from its parent.                       |
+
+```ts
+export type NavbarLabels = {
+  openMenuLabel: string // aria-label on hamburger button (desktop)
+  closeLabel: ReactNodeLabel // visible button text — hamburger toggle shows "Close"
+  menuLabel: ReactNodeLabel // visible button text — hamburger toggle shows "Menu"
+  goBackLabel: string // aria-label on back button (NavbarMobile.tsx)
+  closeMenuLabel: string // aria-label on close button (NavbarMobile.tsx)
+  closeButtonText: ReactNodeLabel // visible "Close" text inside close button (NavbarMobile.tsx)
+}
+```
+
+**Defaults:** `{ openMenuLabel: 'Open menu', closeLabel: 'Close', menuLabel: 'Menu', goBackLabel: 'Go back', closeMenuLabel: 'Close menu', closeButtonText: 'Close' }`
+
+**Implementation detail:** `Navbar/index.tsx` calls `useLabels('Navbar', labels)` and passes individual label values (or the whole resolved object) as props to `NavbarMobile`.
+
+---
+
+#### TASK B-5: LegendItem
+
+| Field                 | Value                                                                                                                                                                                                             |
+| --------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **File**              | `src/components/Geospatial/Legends/LegendItem/index.tsx`                                                                                                                                                          |
+| **Hardcoded strings** | `'Drag and drop'` (aria-label), `'Up'` (aria-label), `'Down'` (aria-label), `'Remove'` (visible text), `'About data'` (visible text / `infoButtonLabel` prop default)                                             |
+| **Classification**    | Mixed                                                                                                                                                                                                             |
+| **Notes**             | `'About data'` is currently the default value of the `infoButtonLabel` prop. Converting it to a label key maintains backward compatibility — the label key's default becomes the fallback if the prop is not set. |
+
+```ts
+export type LegendItemLabels = {
+  dragAndDropLabel: string // aria-label on drag handle
+  upLabel: string // aria-label on move-up button
+  downLabel: string // aria-label on move-down button
+  removeLabel: ReactNodeLabel // visible text on remove button
+  aboutDataLabel: ReactNodeLabel // visible text on info button
+}
+```
+
+**Defaults:** `{ dragAndDropLabel: 'Drag and drop', upLabel: 'Up', downLabel: 'Down', removeLabel: 'Remove', aboutDataLabel: 'About data' }`
+
+---
+
+#### TASK B-6: Toolbar
+
+| Field                 | Value                                                                                        |
+| --------------------- | -------------------------------------------------------------------------------------------- |
+| **File**              | `src/components/Forms/Actions/Toolbar/index.tsx`                                             |
+| **Hardcoded strings** | `'Collapse'` (visible text on overflow toggle), `'Expand'` (visible text on overflow toggle) |
+| **Classification**    | Visual-only                                                                                  |
+
+```ts
+export type ToolbarLabels = {
+  collapseLabel: ReactNodeLabel // visible text — overflow collapse button
+  expandLabel: ReactNodeLabel // visible text — overflow expand button
+}
+```
+
+**Defaults:** `{ collapseLabel: 'Collapse', expandLabel: 'Expand' }`
+
+---
+
+#### TASK B-7: OpacityControl
+
+| Field                 | Value                                                                                                                                                              |
+| --------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| **File**              | `src/components/Geospatial/Legends/OpacityControl/index.tsx`                                                                                                       |
+| **Hardcoded strings** | `'Opacity'` ×3 (button label, `<p>` heading, `aria-label` on input), `'%'` (visible suffix)                                                                        |
+| **Classification**    | Mixed — see per-key                                                                                                                                                |
+| **Notes**             | The button label flows into `<Button label={...}>` which is typed as `string`. The three `'Opacity'` strings serve different purposes and should be separate keys. |
+
+```ts
+export type OpacityControlLabels = {
+  opacityButtonLabel: string // Button.label prop — must be string
+  opacityHeading: ReactNodeLabel // visible <p> heading in popover
+  opacityAriaLabel: string // aria-label on the slider/input
+  percentSuffix: ReactNodeLabel // visible '%' text next to value
+}
+```
+
+**Defaults:** `{ opacityButtonLabel: 'Opacity', opacityHeading: 'Opacity', opacityAriaLabel: 'Opacity', percentSuffix: '%' }`
+
+---
+
+#### Tier B — Aggregate Type Definitions
+
+```ts
+export type RadioListLabels = {
+  requiredLabel: string
+  optionalLabel: string
+  errorPrefix: string
+  requiredSymbolLabel: string
+}
+export type SelectLabels = {
+  defaultAriaLabel: string
+  requiredSuffix: string
+  disabledSuffix: string
+}
+export type NavigationRailLabels = {
+  showLabel: ReactNodeLabel
+  hideLabel: ReactNodeLabel
+  sidebarLabel: ReactNodeLabel
+}
+export type NavbarLabels = {
+  openMenuLabel: string
+  closeLabel: ReactNodeLabel
+  menuLabel: ReactNodeLabel
+  goBackLabel: string
+  closeMenuLabel: string
+  closeButtonText: ReactNodeLabel
+}
+export type LegendItemLabels = {
+  dragAndDropLabel: string
+  upLabel: string
+  downLabel: string
+  removeLabel: ReactNodeLabel
+  aboutDataLabel: ReactNodeLabel
+}
+export type ToolbarLabels = {
+  collapseLabel: ReactNodeLabel
+  expandLabel: ReactNodeLabel
+}
+export type OpacityControlLabels = {
+  opacityButtonLabel: string
+  opacityHeading: ReactNodeLabel
+  opacityAriaLabel: string
+  percentSuffix: ReactNodeLabel
+}
+```
+
+---
+
+### 6.3 Tier C — Complex Components (7 tasks, ~41 label keys)
+
+Components with 6+ strings or interpolation patterns requiring function signatures.
+
+---
+
+#### TASK C-1: Textarea
+
+| Field                 | Value                                                                                                                                                                                          |
+| --------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **File**              | `src/components/Forms/Inputs/Textarea/index.tsx`                                                                                                                                               |
+| **Hardcoded strings** | 9 strings: `'required'` (aria-label), `' (Optional)'` (visible suffix), `'Error:'` (aria-label prefix), + 6 character count messages with numeric interpolation                                |
+| **Classification**    | Mixed — see per-key                                                                                                                                                                            |
+| **Notes**             | Character count messages are dual-use (visible text + fed into helper/error context). Use function signatures for interpolation. Verify exact English wording by reading the component source. |
+
+```ts
+export type TextareaLabels = {
+  requiredSymbolLabel: string // aria-label on (*) indicator
+  optionalSuffix: ReactNodeLabel // visible "(Optional)" suffix
+  errorPrefix: string // "Error:" prefix in aria-label
+  enterAtLeastChars: (n: number) => string // "Enter at least {n} characters"
+  minChars: (n: number) => string // "{n} characters minimum"
+  charsRemaining: (n: number) => string // "{n} characters remaining"
+  maxChars: (n: number) => string // "{n} characters maximum"
+  needMoreChars: (n: number) => string // "Need {n} more characters"
+  tooManyChars: (n: number) => string // "{n} characters over limit"
+}
+```
+
+**Defaults:**
+
+```ts
+{
+  requiredSymbolLabel: 'required',
+  optionalSuffix: ' (Optional)',
+  errorPrefix: 'Error:',
+  enterAtLeastChars: (n) => `Enter at least ${n} characters`,
+  minChars: (n) => `${n} characters minimum`,
+  charsRemaining: (n) => `${n} characters remaining`,
+  maxChars: (n) => `${n} characters maximum`,
+  needMoreChars: (n) => `Need ${n} more characters`,
+  tooManyChars: (n) => `${n} characters over limit`,
+}
+```
+
+> **Implementation note:** Verify the exact English messages by reading the source. The function names and default text above are derived from the audit — exact phrasing may differ slightly.
+
+---
+
+#### TASK C-2: Pagination
+
+| Field                 | Value                                                                                                                                                                                           |
+| --------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **File**              | `src/components/Navigation/Pagination/index.tsx`                                                                                                                                                |
+| **Hardcoded strings** | `'Previous'` (visible), `'Next'` (visible), `'Previous page'` (aria-label), `'Next page'` (aria-label), `'Pagination'` (container aria-label), `` `Page ${page.value}` `` (per-page aria-label) |
+| **Classification**    | Mixed                                                                                                                                                                                           |
+
+```ts
+export type PaginationLabels = {
+  previousLabel: ReactNodeLabel // visible "Previous" button text
+  nextLabel: ReactNodeLabel // visible "Next" button text
+  previousPageLabel: string // aria-label on previous icon button
+  nextPageLabel: string // aria-label on next icon button
+  paginationLabel: string // aria-label on the nav container
+  pageLabel: (page: number) => string // aria-label per page button: "Page 3"
+}
+```
+
+**Defaults:**
+
+```ts
+{
+  previousLabel: 'Previous',
+  nextLabel: 'Next',
+  previousPageLabel: 'Previous page',
+  nextPageLabel: 'Next page',
+  paginationLabel: 'Pagination',
+  pageLabel: (page) => `Page ${page}`,
+}
+```
+
+---
+
+#### TASK C-3: ItemCount
+
+| Field                 | Value                                                                                                |
+| --------------------- | ---------------------------------------------------------------------------------------------------- |
+| **File**              | `src/components/DataDisplay/ItemCount/index.tsx`                                                     |
+| **Hardcoded strings** | `'Per Page'` (visible text), `` `Showing ${startItem}-${endItem} of ${totalItems}` `` (visible text) |
+| **Classification**    | Both Visual-only                                                                                     |
+
+```ts
+export type ItemCountLabels = {
+  perPageLabel: ReactNodeLabel // visible <p> text
+  showingLabel: (start: number, end: number, total: number) => ReactNode // visible interpolated text
+}
+```
+
+**Defaults:**
+
+```ts
+{
+  perPageLabel: 'Per Page',
+  showingLabel: (start, end, total) => `Showing ${start}-${end} of ${total}`,
+}
+```
+
+---
+
+#### TASK C-4: LayerGroup
+
+| Field                 | Value                                                                                                                                           |
+| --------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------- |
+| **File**              | `src/components/Geospatial/Layers/LayerGroup/index.tsx`                                                                                         |
+| **Hardcoded strings** | `` `${count} Active` `` (visible Tag text), `` `${label}${caption}, ${activeCount} Active layers on the map` `` (aria-label on group container) |
+| **Classification**    | Mixed — Tag text is visual-only, group label is A11y-only                                                                                       |
+| **Notes**             | The `aria-label` is a complex template involving label, caption, and active count. Use a function signature.                                    |
+
+```ts
+export type LayerGroupLabels = {
+  activeTagLabel: (count: number) => ReactNode // visible Tag: "3 Active"
+  groupAriaLabel: (
+    label: string,
+    activeCount: number,
+    caption?: string,
+  ) => string // full aria-label builder
+}
+```
+
+**Defaults:**
+
+```ts
+{
+  activeTagLabel: (count) => `${count} Active`,
+  groupAriaLabel: (label, activeCount, caption) =>
+    `${label}${caption ? ', ' + caption : ''}, ${activeCount} Active layers on the map`,
+}
+```
+
+---
+
+#### TASK C-5: QualitativeAttribute
+
+| Field                 | Value                                                                                                                                                                                    |
+| --------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **File**              | `src/components/Geospatial/Legends/QualitativeAttribute/index.tsx`                                                                                                                       |
+| **Hardcoded strings** | `'Hide'`/`'Show'` (visible button text), `'visible'`/`'hidden'` (inside aria-label), `'line,'` (type prefix in aria-label), `'. Currently visible/hidden.'` (aria-label suffix template) |
+| **Classification**    | Mixed — button text is visual-only, status words are a11y-only embedded in template                                                                                                      |
+| **Notes**             | The `aria-label` is built from multiple fragments. A `currentlyTemplate` function gives consumers full control over the final accessible name.                                           |
+
+```ts
+export type QualitativeAttrLabels = {
+  hideLabel: ReactNodeLabel // visible "Hide" button text
+  showLabel: ReactNodeLabel // visible "Show" button text
+  visibleText: string // "visible" — used inside aria-label
+  hiddenText: string // "hidden" — used inside aria-label
+  linePrefix: string // "line," — type prefix in aria-label
+  currentlyTemplate: (
+    label: string,
+    caption: string | undefined,
+    typeText: string,
+    visibilityText: string,
+  ) => string // full aria-label builder
+}
+```
+
+**Defaults:**
+
+```ts
+{
+  hideLabel: 'Hide',
+  showLabel: 'Show',
+  visibleText: 'visible',
+  hiddenText: 'hidden',
+  linePrefix: 'line,',
+  currentlyTemplate: (label, caption, typeText, visibilityText) =>
+    `${label}${caption ? ', ' + caption : ''} ${typeText}. Currently ${visibilityText}.`,
+}
+```
+
+---
+
+#### TASK C-6: MapControlsToolbar
+
+| Field                 | Value                                                                                                                                       |
+| --------------------- | ------------------------------------------------------------------------------------------------------------------------------------------- |
+| **File**              | `src/components/Forms/Actions/Toolbar/presets/MapControl/index.tsx`                                                                         |
+| **Hardcoded strings** | 15 strings: 7 visible button labels + 7 matching `aria-label`s + 1 toolbar `aria-label`                                                     |
+| **Classification**    | Button text = Visual-only, aria-labels = A11y-only                                                                                          |
+| **Notes**             | This is a preset built on top of `Toolbar`. Its labels are independent of `ToolbarLabels`. Verify exact default text by reading the source. |
+
+```ts
+export type MapControlsToolbarLabels = {
+  // Visible button text (ReactNodeLabel)
+  zoomInLabel: ReactNodeLabel
+  zoomOutLabel: ReactNodeLabel
+  expandLabel: ReactNodeLabel
+  shareLabel: ReactNodeLabel
+  printLabel: ReactNodeLabel
+  settingsLabel: ReactNodeLabel
+  helpLabel: ReactNodeLabel
+  // Aria-labels (string)
+  zoomInAriaLabel: string
+  zoomOutAriaLabel: string
+  expandAriaLabel: string
+  shareAriaLabel: string
+  printAriaLabel: string
+  settingsAriaLabel: string
+  helpAriaLabel: string
+  // Container
+  toolbarAriaLabel: string
+}
+```
+
+**Defaults:**
+
+```ts
+{
+  zoomInLabel: 'Zoom in', zoomOutLabel: 'Zoom out', expandLabel: 'Expand',
+  shareLabel: 'Share', printLabel: 'Print', settingsLabel: 'Settings', helpLabel: 'Help',
+  zoomInAriaLabel: 'Zoom in', zoomOutAriaLabel: 'Zoom out', expandAriaLabel: 'Expand',
+  shareAriaLabel: 'Share', printAriaLabel: 'Print', settingsAriaLabel: 'Settings',
+  helpAriaLabel: 'Help', toolbarAriaLabel: 'Map controls',
+}
+```
+
+---
+
+#### TASK C-7: StepProgressIndicator
+
+| Field                 | Value                                                                                                         |
+| --------------------- | ------------------------------------------------------------------------------------------------------------- |
+| **File**              | `src/components/Status/StepProgressIndicator/index.tsx`                                                       |
+| **Hardcoded strings** | `` `Current Step ${idx}: ${label}. ${isCompleted ? 'Completed' : 'Not completed'}.` `` (dynamic `aria-label`) |
+| **Classification**    | A11y-only (aria-label template)                                                                               |
+
+```ts
+export type StepProgressIndicatorLabels = {
+  currentStepLabel: (
+    step: number,
+    label: string,
+    isCompleted: boolean,
+  ) => string
+}
+```
+
+**Defaults:**
+
+```ts
+{
+  currentStepLabel: (step, label, isCompleted) =>
+    `Current Step ${step}: ${label}. ${isCompleted ? 'Completed' : 'Not completed'}.`,
+}
+```
+
+> **Implementation note:** Verify exact interpolation pattern by reading the source.
+
+---
+
+### 6.4 Interpolated String Strategy
+
+Components with dynamic values use **function signatures** (Option A) rather than template strings:
+
+```ts
+// Option A — format function (recommended, most flexible)
+showingLabel: (start: number, end: number, total: number) => ReactNode
+
+// Option B — template string (less flexible, can't handle pluralization)
+showingLabel: string
+```
+
+**Rationale:** Function signatures allow consumers to:
+
+- Handle pluralization via their own ICU library
+- Format numbers according to locale (e.g., thousands separators)
+- Return JSX elements (when `ReactNode` return type) for rich formatting
+
+---
+
+## 7. Task Definitions — Phase 4
+
+### TASK P4-1: Storybook i18n Documentation Page
+
+| Field              | Value                                                                                                                                                                                                                                        |
+| ------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **File to create** | `src/components/docs/i18n.mdx`                                                                                                                                                                                                               |
+| **Depends on**     | All Phase 3 components migrated                                                                                                                                                                                                              |
+| **Deliverables**   | MDX page with: props + context pattern diagram, full label catalog (table per component), integration examples (react-intl, react-i18next, vanilla), context vs per-component trade-offs, "Adding i18n to a new component" contributor guide |
+
+---
+
+### TASK P4-2: Public API Export Audit
+
+| Field            | Value                                                                                                               |
+| ---------------- | ------------------------------------------------------------------------------------------------------------------- |
+| **Files**        | `src/lib/i18n/index.ts`, `src/components/index.ts`                                                                  |
+| **Depends on**   | All Phase 3 components migrated                                                                                     |
+| **Deliverables** | Every `XxxLabels` type exported from both barrel files so consumers can type translation maps without deep imports. |
+
+---
+
+### TASK P4-3: ESLint Hardcoded String Guard (Optional)
+
+| Field            | Value                                                                                      |
+| ---------------- | ------------------------------------------------------------------------------------------ |
+| **File**         | `.eslintrc` or `eslint.config.js`                                                          |
+| **Depends on**   | None — can be done anytime                                                                 |
+| **Deliverables** | `no-restricted-syntax` rule warning on hardcoded `aria-label` strings in `src/components/` |
+
+```json
+{
+  "rules": {
+    "no-restricted-syntax": [
+      "warn",
+      {
+        "selector": "JSXAttribute[name.name='aria-label'] > Literal",
+        "message": "Hardcoded aria-label detected. Use a labels prop via useLabels()."
+      }
+    ]
+  }
+}
+```
+
+---
+
+### TASK P4-4: CHANGELOG Entry
+
+| Field            | Value                                                                                                                              |
+| ---------------- | ---------------------------------------------------------------------------------------------------------------------------------- |
+| **File**         | `CHANGELOG.md`                                                                                                                     |
+| **Depends on**   | All Phase 3 components migrated                                                                                                    |
+| **Deliverables** | `Added` entry documenting `DesignSystemLocaleProvider`, `labels` prop, full list of migrated components. `BREAKING CHANGES: none`. |
+
+---
+
+## 8. Progress Tracker
+
+### Phase 1–2: Infrastructure + Reference Implementations
+
+| Item                                  | Status                          |
+| ------------------------------------- | ------------------------------- |
+| i18n infrastructure (`src/lib/i18n/`) | ✅ Done — `DS-273`              |
+| `CheckboxList` (6 keys)               | ✅ Done — `DS-273`              |
+| `Password` (17 keys)                  | ✅ Done — `DS-273`              |
+| `TextInput` (2 keys)                  | ✅ Done — `DS-273`              |
+| ReactNode type widening               | ✅ Done — `DS-273-expand-props` |
+
+### Phase 3: Component Migration
+
+| Task | Component               | Tier | Keys | Status         |
+| ---- | ----------------------- | ---- | ---- | -------------- |
+| A-1  | `CloseButton`           | A    | 1    | ⬜ Not started |
+| A-2  | `Toast`                 | A    | 1    | ⬜ Not started |
+| A-3  | `InlineMessage`         | A    | 1    | ⬜ Not started |
+| A-4  | `MapPopUp`              | A    | 1    | ⬜ Not started |
+| A-5  | `AnalysisWidget`        | A    | 1    | ⬜ Not started |
+| A-6  | `Table`                 | A    | 2    | ⬜ Not started |
+| A-7  | `Button`                | A    | 1    | ⬜ Not started |
+| A-8  | `BaseMap`               | A    | 1    | ⬜ Not started |
+| A-9  | `Search`                | A    | 2    | ⬜ Not started |
+| B-1  | `RadioList`             | B    | 4    | ⬜ Not started |
+| B-2  | `Select`                | B    | 3    | ⬜ Not started |
+| B-3  | `NavigationRail`        | B    | 3    | ⬜ Not started |
+| B-4  | `Navbar`                | B    | 6    | ⬜ Not started |
+| B-5  | `LegendItem`            | B    | 5    | ⬜ Not started |
+| B-6  | `Toolbar`               | B    | 2    | ⬜ Not started |
+| B-7  | `OpacityControl`        | B    | 4    | ⬜ Not started |
+| C-1  | `Textarea`              | C    | 9    | ⬜ Not started |
+| C-2  | `Pagination`            | C    | 6    | ⬜ Not started |
+| C-3  | `ItemCount`             | C    | 2    | ⬜ Not started |
+| C-4  | `LayerGroup`            | C    | 2    | ⬜ Not started |
+| C-5  | `QualitativeAttribute`  | C    | 6    | ⬜ Not started |
+| C-6  | `MapControlsToolbar`    | C    | 15   | ⬜ Not started |
+| C-7  | `StepProgressIndicator` | C    | 1    | ⬜ Not started |
+
+### Phase 4: Documentation & Tooling
+
+| Task | Item                          | Status         |
+| ---- | ----------------------------- | -------------- |
+| P4-1 | Storybook i18n docs page      | ⬜ Not started |
+| P4-2 | Public API export audit       | ⬜ Not started |
+| P4-3 | ESLint hardcoded string guard | ⬜ Not started |
+| P4-4 | CHANGELOG entry               | ⬜ Not started |
+
+### Summary
+
+- **Done:** 3 components (25 keys) + infrastructure + ReactNode widening
+- **Remaining:** 23 components (~80 keys) + 4 Phase 4 tasks
+- **Breakdown:** 9 Tier A (11 keys) · 7 Tier B (27 keys) · 7 Tier C (41 keys)
+
+---
+
+## 9. Appendix
+
+### A. Components With No Hardcoded Strings (No Action Required)
+
+These components were audited and confirmed to have no internal English strings:
+
+`AlertBanner`, `Avatar`, `Badge`, `Breadcrumb`, `Checkbox`, `CheckboxOptionCard`, `ExtendableCard`, `Footer`, `FormContainer`, `IconButton`, `InputWithUnits`, `LayerGroupContainer`, `LayerItem`, `LayerParameters`, `List`, `MapMarker`, `Menu`, `MobileTabBar`, `Modal`, `MultiActionButton`, `OptionCard`, `Panel`, `ProgressBar`, `Radio`, `RadioGroup`, `ScaleBar`, `Sheet`, `Slider`, `SliderInput`, `Switch`, `TabBar`, `Tag`, `Tooltip`
+
+### B. DesignSystemLabels Final Shape (After Full Migration)
+
+```ts
+export type DesignSystemLabels = {
+  // Phase 1–2 (done)
+  CheckboxList?: Partial<CheckboxListLabels>
+  Password?: Partial<PasswordLabels>
+  TextInput?: Partial<TextInputLabels>
+  // Tier A
+  CloseButton?: Partial<CloseButtonLabels>
+  Toast?: Partial<ToastLabels>
+  InlineMessage?: Partial<InlineMessageLabels>
+  MapPopUp?: Partial<MapPopUpLabels>
+  AnalysisWidget?: Partial<AnalysisWidgetLabels>
+  Table?: Partial<TableLabels>
+  Button?: Partial<ButtonLabels>
+  BaseMap?: Partial<BaseMapLabels>
+  Search?: Partial<SearchLabels>
+  // Tier B
+  RadioList?: Partial<RadioListLabels>
+  Select?: Partial<SelectLabels>
+  NavigationRail?: Partial<NavigationRailLabels>
+  Navbar?: Partial<NavbarLabels>
+  LegendItem?: Partial<LegendItemLabels>
+  Toolbar?: Partial<ToolbarLabels>
+  OpacityControl?: Partial<OpacityControlLabels>
+  // Tier C
+  Textarea?: Partial<TextareaLabels>
+  Pagination?: Partial<PaginationLabels>
+  ItemCount?: Partial<ItemCountLabels>
+  LayerGroup?: Partial<LayerGroupLabels>
+  QualitativeAttribute?: Partial<QualitativeAttrLabels>
+  MapControlsToolbar?: Partial<MapControlsToolbarLabels>
+  StepProgressIndicator?: Partial<StepProgressIndicatorLabels>
+}
+```
+
+### C. defaultLabels Growth Pattern
+
+The `DefaultLabels` type in `defaultLabels.ts` must grow in lockstep with `DesignSystemLabels`. Each new entry uses `Required<XxxLabels>` to ensure all keys have defaults:
+
+```ts
+type DefaultLabels = {
+  CheckboxList: Required<CheckboxListLabels>
+  Password: Required<PasswordLabels>
+  TextInput: Required<TextInputLabels>
+  // ... one entry per migrated component, added with each task
+}
+```
+
+The `useLabels` hook uses `keyof typeof defaultLabels` to constrain valid component names — a component cannot use `useLabels` until its defaults are registered.


### PR DESCRIPTION
## What

Adds a comprehensive i18n documentation file and updates all AI instruction files to include opt-in guidance for internationalizing WRI DS components.

## Why

Phase 3 of DS-274 (i18n rollout) introduced `DesignSystemLocaleProvider`, `useLabels`, and `XxxLabels` types across 26 components. AI contributors and consumers now need guidance on how the system works, how to author new translatable components, and how to consume the i18n API — without impacting English-only workflows.

## Changes

### New files
- `docs/i18n/README.md` — full i18n reference for consumers and contributors. Covers architecture, resolution flow, public API, all three usage patterns (provider app-wide, per-component `labels` prop, mixed), a complete label type reference table for all 26 supported components, and a real-world case study from `gri-restoration-diagnostic` with three annotated code patterns
- `i18n-rollout.md` — internal low-level design doc tracking Phases 1–4 of the i18n rollout (previously untracked)

### AI instruction files — contributor layer (`contributor-ai/`)
- **`component.instructions.md`** — added optional checklist step 8 (i18n) and a new `## Internationalization (i18n)` section with the 5-step implementation procedure and string classification rules
- **`CONTRIBUTOR.md`** — added a `## Internationalization (i18n) — Optional` section parallel to the existing Accessibility block
- **`wri-component-builder.agent.md`** — added optional workflow step 9 (i18n) and a conditional self-check item

### AI instruction files — consumer layer (`agents/`)
- **`AGENTS.md`** — added `## Internationalization (i18n) — Optional` section with a minimal provider example
- **`wri-ds.instructions.md`** — added `## Internationalization (i18n)` section covering both usage patterns with the rule: never pass hardcoded English literals into `labels` props

All i18n additions are framed as **opt-in**. The library defaults to English; no changes are required for English-only consumers or components without internal strings.