### PR TITLE
[DS-309] - storybook containers

### DIFF
--- a/src/components/Forms/Inputs/TextInput/TextInput.stories.tsx
+++ b/src/components/Forms/Inputs/TextInput/TextInput.stories.tsx
@@ -19,6 +19,13 @@ const meta = {
     },
   },
   tags: ['autodocs'],
+  decorators: [
+    (Story: any) => (
+      <div style={{ width: '15.625rem' }}>
+        <Story />
+      </div>
+    ),
+  ],
   argTypes: {
     label: { description: 'Field label', control: 'text' },
     placeholder: { description: 'Placeholder text', control: 'text' },

--- a/src/components/Forms/Inputs/Textarea/Textarea.stories.tsx
+++ b/src/components/Forms/Inputs/Textarea/Textarea.stories.tsx
@@ -18,6 +18,13 @@ const meta = {
     },
   },
   tags: ['autodocs'],
+  decorators: [
+    (Story: any) => (
+      <div style={{ width: '15.625rem' }}>
+        <Story />
+      </div>
+    ),
+  ],
   argTypes: {
     label: { description: 'Field label', control: 'text' },
     placeholder: { description: 'Placeholder text', control: 'text' },

--- a/src/components/Navigation/Search/Search.stories.tsx
+++ b/src/components/Navigation/Search/Search.stories.tsx
@@ -20,6 +20,13 @@ const meta = {
     },
   },
   tags: ['autodocs'],
+  decorators: [
+    (Story: any) => (
+      <div style={{ width: '15.625rem' }}>
+        <Story />
+      </div>
+    ),
+  ],
   argTypes: {
     placeholder: { description: 'Placeholder text', control: 'text' },
     disabled: { description: 'Disables the search input', control: 'boolean' },

--- a/src/components/Status/InlineMessage/InlineMessage.stories.tsx
+++ b/src/components/Status/InlineMessage/InlineMessage.stories.tsx
@@ -21,6 +21,13 @@ const meta = {
   },
   tags: ['autodocs'],
   args: { onActionClick: fn() },
+  decorators: [
+    (Story: any) => (
+      <div style={{ width: '31.25rem' }}>
+        <Story />
+      </div>
+    ),
+  ],
   argTypes: {
     label: { description: '`label` text', control: 'text' },
     caption: { description: '`caption` content', control: false },


### PR DESCRIPTION
## What

Added consistent decorators to Storybook stories for better layout control.

## Why

To ensure consistent width styling across Storybook stories, improving the visual presentation and usability during development.

## Changes

- **TextInput.stories.tsx**: Added a decorator to wrap stories in a `div` with a fixed width of `15.625rem`.
- **Textarea.stories.tsx**: Added a decorator to wrap stories in a `div` with a fixed width of `15.625rem`.
- **Search.stories.tsx**: Added a decorator to wrap stories in a `div` with a fixed width of `15.625rem`.
- **InlineMessage.stories.tsx**: Added a decorator to wrap stories in a `div` with a fixed width of `31.25rem`.

