### PR TITLE
[DS-312] - Toast updates + minor fixes

### DIFF
--- a/agents/setup-ai.mjs
+++ b/agents/setup-ai.mjs
@@ -85,6 +85,7 @@ function ensureGitignoreBlock() {
     '.windsurfrules',
     '.clinerules',
     '.github/copilot-instructions.md',
+    '.github/instructions/wri-ds.instructions.md',
     '.cursor/rules',
     '.cursor/mcp.json',
     '.vscode/mcp.json',

--- a/src/components/DataDisplay/ItemCount/ItemCountDemo.tsx
+++ b/src/components/DataDisplay/ItemCount/ItemCountDemo.tsx
@@ -12,6 +12,7 @@ const ItemCountDemo = () => {
         currentPage={1}
         totalItems={100}
         onPageSizeChange={setPageSize}
+        showItemCountText
       />
     </DemoWrapper>
   )

--- a/src/components/DataDisplay/ItemCount/styles.ts
+++ b/src/components/DataDisplay/ItemCount/styles.ts
@@ -15,7 +15,7 @@ export const itemCountPerPageContainerStyles = css`
   display: flex;
   gap: ${getThemedSpacing(400)};
   align-items: center;
-  margin-bottom: ${getThemedSpacing(600)};
+  margin-bottom: ${getThemedSpacing(300)};
 
   .ds-select-input-container {
     margin-bottom: 0rem;

--- a/src/components/Forms/Actions/MultiActionButton/index.tsx
+++ b/src/components/Forms/Actions/MultiActionButton/index.tsx
@@ -90,6 +90,7 @@ const MultiActionButton = ({
             size={size}
             leftIcon={
               <ChevronDownIcon
+                aria-hidden='true'
                 rotate={isOpen ? '180' : '0'}
                 color={
                   getThemedColor('accessible', 'text-on-primary-mids') ||

--- a/src/components/Status/InlineMessage/InlineMessageDemo.tsx
+++ b/src/components/Status/InlineMessage/InlineMessageDemo.tsx
@@ -9,7 +9,7 @@ const InlineMessageDemo = () => (
         display: 'flex',
         alignItems: 'center',
         flexWrap: 'wrap',
-        gap: '0.5rem',
+        gap: '1.25rem',
       }}
     >
       <InlineMessage

--- a/src/components/Status/InlineMessage/styled.ts
+++ b/src/components/Status/InlineMessage/styled.ts
@@ -31,7 +31,6 @@ export const defaultInlineMessageStyles = (
     justify-content: ${isButtonRight ? 'space-between' : 'flex-start'};
     flex-direction: ${isButtonRight ? 'row' : 'column'};
     gap: ${getThemedSpacing(200)};
-    margin-bottom: ${getThemedSpacing(400)};
 
     button {
       margin-left: ${isButtonRight ? 0 : getThemedSpacing(600)};

--- a/src/components/Status/Toast/README.md
+++ b/src/components/Status/Toast/README.md
@@ -34,6 +34,7 @@ showToast({
   },
   closable: true,
   closableLabel: 'Dismiss',
+  onClose: () => console.log('Closed'),
 })
 ```
 
@@ -44,7 +45,13 @@ type ToastProps = {
   label: string
   caption?: React.ReactNode
   type: 'success' | 'warning' | 'error' | 'info' | 'loading'
-  placement: 'top-start' | 'top-end' | 'bottom-start' | 'bottom-end'
+  placement:
+    | 'top-start'
+    | 'top'
+    | 'top-end'
+    | 'bottom-start'
+    | 'bottom'
+    | 'bottom-end'
   duration?: number
   icon?: React.ReactNode
   action?: {
@@ -53,6 +60,7 @@ type ToastProps = {
   }
   closable?: boolean
   closableLabel?: string
+  onClose?: () => void
 }
 ```
 
@@ -188,6 +196,17 @@ showToast({
 })
 ```
 
+### Top Center
+
+```tsx
+showToast({
+  label: 'Label',
+  caption: 'Caption',
+  type: 'success',
+  placement: 'top',
+})
+```
+
 ### Top End
 
 ```tsx
@@ -210,6 +229,17 @@ showToast({
 })
 ```
 
+### Bottom Center
+
+```tsx
+showToast({
+  label: 'Label',
+  caption: 'Caption',
+  type: 'success',
+  placement: 'bottom',
+})
+```
+
 ### Bottom End
 
 ```tsx
@@ -218,5 +248,17 @@ showToast({
   caption: 'Caption',
   type: 'success',
   placement: 'bottom-end',
+})
+```
+
+### OnClose
+
+```tsx
+showToast({
+  label: 'Label',
+  caption: 'Caption',
+  type: 'success',
+  placement: 'bottom-end',
+  onClose: () => console.log('Closed'),
 })
 ```

--- a/src/components/Status/Toast/README.md
+++ b/src/components/Status/Toast/README.md
@@ -259,6 +259,7 @@ showToast({
   caption: 'Caption',
   type: 'success',
   placement: 'bottom-end',
+  closable: true,
   onClose: () => console.log('Closed'),
 })
 ```

--- a/src/components/Status/Toast/Toast.stories.tsx
+++ b/src/components/Status/Toast/Toast.stories.tsx
@@ -260,6 +260,25 @@ export const TopLeft: Story = {
   ],
 }
 
+export const TopCenter: Story = {
+  decorators: [
+    () => (
+      <Button
+        label='Show Toast'
+        variant='primary'
+        onClick={() =>
+          showToast({
+            label: 'Label',
+            caption: 'Caption',
+            type: 'success',
+            placement: 'top',
+          })
+        }
+      />
+    ),
+  ],
+}
+
 export const TopRight: Story = {
   decorators: [
     () => (
@@ -298,6 +317,25 @@ export const BottomLeft: Story = {
   ],
 }
 
+export const BottomCenter: Story = {
+  decorators: [
+    () => (
+      <Button
+        label='Show Toast'
+        variant='primary'
+        onClick={() =>
+          showToast({
+            label: 'Label',
+            caption: 'Caption',
+            type: 'success',
+            placement: 'bottom',
+          })
+        }
+      />
+    ),
+  ],
+}
+
 export const BottomRight: Story = {
   decorators: [
     () => (
@@ -310,6 +348,27 @@ export const BottomRight: Story = {
             caption: 'Caption',
             type: 'success',
             placement: 'bottom-end',
+          })
+        }
+      />
+    ),
+  ],
+}
+
+export const OnClose: Story = {
+  decorators: [
+    () => (
+      <Button
+        label='Show Toast'
+        variant='primary'
+        onClick={() =>
+          showToast({
+            label: 'Label',
+            caption: 'Caption',
+            type: 'success',
+            placement: 'bottom-end',
+            closable: true,
+            onClose: () => console.log('Closed'),
           })
         }
       />

--- a/src/components/Status/Toast/ToastDemo.tsx
+++ b/src/components/Status/Toast/ToastDemo.tsx
@@ -31,6 +31,19 @@ const ToastDemo = () => (
         }
       />
       <Button
+        label='Info - Top Center'
+        variant='primary'
+        onClick={() =>
+          showToast({
+            label: 'Label',
+            caption: 'Caption',
+            type: 'info',
+            placement: 'top',
+            closable: true,
+          })
+        }
+      />
+      <Button
         label='Success - Top Right'
         variant='primary'
         onClick={() =>
@@ -56,6 +69,20 @@ const ToastDemo = () => (
             caption: 'Caption',
             type: 'warning',
             placement: 'bottom-start',
+          })
+        }
+      />
+      <Button
+        label='Info - Bottom Center'
+        variant='primary'
+        onClick={() =>
+          showToast({
+            label: 'Label',
+            caption: 'Caption',
+            type: 'info',
+            placement: 'bottom',
+            closable: true,
+            onClose: () => console.log('Closed'),
           })
         }
       />

--- a/src/components/Status/Toast/index.tsx
+++ b/src/components/Status/Toast/index.tsx
@@ -115,7 +115,13 @@ const Toast: React.FC<ToastComponentProps> = ({ labels }) => {
                     }
                     size='small'
                     variant='secondary'
-                    onClick={() => toasters[toaster].dismiss()}
+                    onClick={() => {
+                      if (toast.meta?.onClose) {
+                        toast.meta.onClose()
+                      }
+
+                      toasters[toaster].dismiss()
+                    }}
                   />
                 ) : null}
               </Stack>

--- a/src/components/Status/Toast/types.ts
+++ b/src/components/Status/Toast/types.ts
@@ -6,7 +6,13 @@ export type ToastProps = {
   label: string
   caption?: React.ReactNode
   type: 'success' | 'warning' | 'error' | 'info' | 'loading'
-  placement: 'top-start' | 'top-end' | 'bottom-start' | 'bottom-end'
+  placement:
+    | 'top-start'
+    | 'top'
+    | 'top-end'
+    | 'bottom-start'
+    | 'bottom'
+    | 'bottom-end'
   duration?: number
   icon?: React.ReactNode
   action?: {
@@ -15,6 +21,7 @@ export type ToastProps = {
   }
   closable?: boolean
   closableLabel?: string
+  onClose?: () => void
 }
 
 export type ToastComponentProps = {

--- a/src/components/Status/Toast/utils.ts
+++ b/src/components/Status/Toast/utils.ts
@@ -11,6 +11,11 @@ const topStartToast = createToaster({
   ...commonProps,
 })
 
+const topToast = createToaster({
+  placement: 'top',
+  ...commonProps,
+})
+
 const topEndToast = createToaster({
   placement: 'top-end',
   ...commonProps,
@@ -21,6 +26,11 @@ const bottomStartToast = createToaster({
   ...commonProps,
 })
 
+const bottomToast = createToaster({
+  placement: 'bottom',
+  ...commonProps,
+})
+
 const bottomEndToast = createToaster({
   placement: 'bottom-end',
   ...commonProps,
@@ -28,8 +38,10 @@ const bottomEndToast = createToaster({
 
 export const toasters: { [key: string]: CreateToasterReturn } = {
   'top-start': topStartToast,
+  top: topToast,
   'top-end': topEndToast,
   'bottom-start': bottomStartToast,
+  bottom: bottomToast,
   'bottom-end': bottomEndToast,
 }
 
@@ -44,6 +56,7 @@ export const showToast = (props: ToastProps) => {
       closable: props.closable,
       icon: props.icon,
       closableLabel: props.closableLabel,
+      onClose: props.onClose,
     },
     ...props,
   })


### PR DESCRIPTION
## What

This PR updates toast placement and dismiss behavior, refreshes a few component demos, and makes a small accessibility cleanup in the design system tooling.

## Why

The toast API needed centered placements and an `onClose` hook so consumers can react when a toast is dismissed. The related demo, story, and documentation updates keep the examples aligned with the new behavior, while the other changes tighten spacing and accessibility details.

## Changes

- Added `top` and `bottom` toast placements and wired them through the toaster setup and `showToast`.
- Added `onClose` support for closable toasts and call it before dismissal.
- Updated toast README examples, stories, and demo buttons to cover the new placements and close callback.
- Adjusted `ItemCount` and `InlineMessage` demos/styles to improve spacing and showcase current behavior.
- Marked the `MultiActionButton` chevron icon as `aria-hidden` for better accessibility.
- Updated `agents/setup-ai.mjs` to ignore the new GitHub instructions path.
- Reorganized PR-related skill docs under the new `pr-description` naming and added the companion helper skill folders.