### PR TITLE
Ds-232 - menu updates

### DIFF
--- a/src/components/Forms/Actions/Menu/Menu.stories.tsx
+++ b/src/components/Forms/Actions/Menu/Menu.stories.tsx
@@ -41,6 +41,16 @@ const meta = {
       description: 'Custom trigger element instead of the default button',
       control: false,
     },
+    selectionMode: {
+      description:
+        'Selection behaviour. "multiple" (default) allows many items checked at once; "radio" allows only one.',
+      control: { type: 'select' },
+      options: ['multiple', 'radio'],
+    },
+    defaultSelectedValues: {
+      description: 'Values checked by default on first render',
+      control: false,
+    },
   },
 } satisfies Meta<typeof MenuStory>
 
@@ -169,6 +179,33 @@ export const WithSubmenu: Story = {
           },
         ],
       },
+    ],
+  },
+}
+
+export const MultipleSelection: Story = {
+  args: {
+    label: 'Language',
+    selectionMode: 'multiple',
+    defaultSelectedValues: ['value-sel-2'],
+    items: [
+      { label: 'English', value: 'value-sel-1' },
+      { label: 'Spanish', value: 'value-sel-2' },
+      { label: 'French', value: 'value-sel-3' },
+      { label: 'German', value: 'value-sel-4' },
+    ],
+  },
+}
+
+export const RadioSelection: Story = {
+  args: {
+    label: 'View mode',
+    selectionMode: 'radio',
+    defaultSelectedValues: ['value-radio-1'],
+    items: [
+      { label: 'Map', value: 'value-radio-1' },
+      { label: 'Table', value: 'value-radio-2' },
+      { label: 'Chart', value: 'value-radio-3' },
     ],
   },
 }

--- a/src/components/Forms/Actions/Menu/MenuDemo.tsx
+++ b/src/components/Forms/Actions/Menu/MenuDemo.tsx
@@ -125,6 +125,31 @@ const MenuDemo = () => (
       />
 
       <Menu
+        label='Language (multiple)'
+        selectionMode='multiple'
+        defaultSelectedValues={['label-5-1']}
+        items={[
+          { label: 'English', value: 'label-5-1' },
+          { label: 'Spanish', value: 'label-5-2' },
+          { label: 'French', value: 'label-5-3' },
+          { label: 'German', value: 'label-5-4', disabled: true },
+        ]}
+        onSelect={(value) => console.log('onSelect', value)}
+      />
+
+      <Menu
+        label='View mode (radio)'
+        selectionMode='radio'
+        defaultSelectedValues={['label-6-1']}
+        items={[
+          { label: 'Map', value: 'label-6-1' },
+          { label: 'Table', value: 'label-6-2' },
+          { label: 'Chart', value: 'label-6-3' },
+        ]}
+        onSelect={(value) => console.log('onSelect', value)}
+      />
+
+      <Menu
         label='With Custom Trigger'
         items={[
           {

--- a/src/components/Forms/Actions/Menu/MenuItem.tsx
+++ b/src/components/Forms/Actions/Menu/MenuItem.tsx
@@ -1,0 +1,70 @@
+/* eslint-disable react/no-unknown-property */
+/** @jsxImportSource @emotion/react */
+
+import React from 'react'
+import { Menu as ChakraMenu } from '@chakra-ui/react'
+import { CheckIcon } from '../../../icons'
+import { MenuItemProps } from './types'
+import {
+  menuItemContainerStyles,
+  menuItemLabelAndCaptionStyles,
+  menuItemLabelCheckedStyles,
+  menuItemLabelContentStyles,
+} from './styled'
+
+const MenuItem = ({
+  item,
+  isLast,
+  isChecked = false,
+}: {
+  item: MenuItemProps
+  isLast: boolean
+  isChecked?: boolean
+}) => (
+  <>
+    <ChakraMenu.Item
+      css={menuItemContainerStyles}
+      value={item.value || item.label || ''}
+      disabled={item.disabled}
+      role='menuitem'
+      aria-label={item.label}
+    >
+      {item.children ? (
+        item.children
+      ) : (
+        <>
+          {item.startIcon}
+          <div
+            css={menuItemLabelAndCaptionStyles(
+              !!item.startIcon,
+              !!item.endIcon,
+            )}
+          >
+            <div css={menuItemLabelContentStyles}>
+              <p
+                css={isChecked ? menuItemLabelCheckedStyles : undefined}
+                className='ds-menu-item-label'
+              >
+                {item.label}
+              </p>
+              {item.command ? (
+                <ChakraMenu.ItemCommand aria-label={`Shortcut ${item.command}`}>
+                  {item.command}
+                </ChakraMenu.ItemCommand>
+              ) : null}
+            </div>
+            {item.caption ? (
+              <p className='ds-menu-item-caption'>{item.caption}</p>
+            ) : null}
+          </div>
+          {isChecked ? <CheckIcon /> : item.endIcon}
+        </>
+      )}
+    </ChakraMenu.Item>
+    {!isLast ? (
+      <ChakraMenu.Separator borderColor='var(--chakra-colors-neutral-300)' />
+    ) : null}
+  </>
+)
+
+export default MenuItem

--- a/src/components/Forms/Actions/Menu/index.tsx
+++ b/src/components/Forms/Actions/Menu/index.tsx
@@ -4,66 +4,16 @@
 
 import React, { useState, useRef, useEffect } from 'react'
 import { Menu as ChakraMenu, Portal } from '@chakra-ui/react'
-import { MenuItemProps, MenuProps } from './types'
+import MenuItem from './MenuItem'
+import { MenuProps } from './types'
 import {
   menuStyles,
   menuContentStyles,
   menuArrowStyles,
-  menuItemContainerStyles,
   menuItemGroupLabelStyles,
-  menuItemLabelAndCaptionStyles,
-  menuItemLabelContentStyles,
   menuSubmenuTriggerStyles,
 } from './styled'
 import { ChevronDownIcon } from '../../../icons'
-
-const MenuItem = ({
-  item,
-  isLast,
-}: {
-  item: MenuItemProps
-  isLast: boolean
-}) => (
-  <>
-    <ChakraMenu.Item
-      css={menuItemContainerStyles}
-      value={item.value || item.label || ''}
-      disabled={item.disabled}
-      role='menuitem'
-      aria-label={item.label}
-    >
-      {item.children ? (
-        item.children
-      ) : (
-        <>
-          {item.startIcon}
-          <div
-            css={menuItemLabelAndCaptionStyles(
-              !!item.startIcon,
-              !!item.endIcon,
-            )}
-          >
-            <div css={menuItemLabelContentStyles}>
-              <p className='ds-menu-item-label'>{item.label}</p>
-              {item.command ? (
-                <ChakraMenu.ItemCommand aria-label={`Shortcut ${item.command}`}>
-                  {item.command}
-                </ChakraMenu.ItemCommand>
-              ) : null}
-            </div>
-            {item.caption ? (
-              <p className='ds-menu-item-caption'>{item.caption}</p>
-            ) : null}
-          </div>
-          {item.endIcon}
-        </>
-      )}
-    </ChakraMenu.Item>
-    {!isLast ? (
-      <ChakraMenu.Separator borderColor='var(--chakra-colors-neutral-300)' />
-    ) : null}
-  </>
-)
 
 const Menu = ({
   theme = 'light',
@@ -73,8 +23,13 @@ const Menu = ({
   groups,
   onSelect,
   customTrigger,
+  selectionMode,
+  defaultSelectedValues = [],
 }: MenuProps) => {
   const [isOpen, setIsOpen] = useState(false)
+  const [selectedValues, setSelectedValues] = useState<Set<string>>(
+    new Set(defaultSelectedValues),
+  )
   const triggerRef = useRef<HTMLButtonElement | null>(null)
 
   // Closes menu when trigger is out of viewport
@@ -95,7 +50,21 @@ const Menu = ({
 
   return (
     <ChakraMenu.Root
-      onSelect={({ value }) => onSelect && onSelect(value)}
+      onSelect={({ value }) => {
+        setSelectedValues((prev) => {
+          const next = new Set(prev)
+          if (selectionMode === 'radio') {
+            next.clear()
+            next.add(value)
+          } else if (next.has(value)) {
+            next.delete(value)
+          } else {
+            next.add(value)
+          }
+          return next
+        })
+        if (onSelect) onSelect(value)
+      }}
       onOpenChange={({ open }) => setIsOpen(open)}
       open={isOpen}
     >
@@ -171,6 +140,10 @@ const Menu = ({
                   key={`${item.value}-${idx}`}
                   item={item}
                   isLast={idx === items.length - 1}
+                  isChecked={
+                    !!selectionMode &&
+                    selectedValues.has(item.value || item.label || '')
+                  }
                 />
               )
             })}
@@ -188,7 +161,17 @@ const Menu = ({
                     {group.title}
                   </ChakraMenu.ItemGroupLabel>
                   {group.items?.map((groupItem) => (
-                    <MenuItem key={groupItem.value} item={groupItem} isLast />
+                    <MenuItem
+                      key={groupItem.value}
+                      item={groupItem}
+                      isLast
+                      isChecked={
+                        !!selectionMode &&
+                        selectedValues.has(
+                          groupItem.value || groupItem.label || '',
+                        )
+                      }
+                    />
                   ))}
                 </ChakraMenu.ItemGroup>
                 {idx !== groups.length - 1 ? (

--- a/src/components/Forms/Actions/Menu/index.tsx
+++ b/src/components/Forms/Actions/Menu/index.tsx
@@ -2,12 +2,13 @@
 /* eslint-disable react/no-unknown-property */
 /** @jsxImportSource @emotion/react */
 
-import React, { useState } from 'react'
+import React, { useState, useRef, useEffect } from 'react'
 import { Menu as ChakraMenu, Portal } from '@chakra-ui/react'
 import { MenuItemProps, MenuProps } from './types'
 import {
   menuStyles,
   menuContentStyles,
+  menuArrowStyles,
   menuItemContainerStyles,
   menuItemGroupLabelStyles,
   menuItemLabelAndCaptionStyles,
@@ -74,6 +75,23 @@ const Menu = ({
   customTrigger,
 }: MenuProps) => {
   const [isOpen, setIsOpen] = useState(false)
+  const triggerRef = useRef<HTMLButtonElement | null>(null)
+
+  // Closes menu when trigger is out of viewport
+  useEffect(() => {
+    if (!isOpen || !triggerRef.current) return
+    const observer = new window.IntersectionObserver(
+      ([entry]) => {
+        if (!entry.isIntersecting) setIsOpen(false)
+      },
+      { threshold: 0.01 },
+    )
+    observer.observe(triggerRef.current)
+    // eslint-disable-next-line consistent-return
+    return () => {
+      observer.disconnect()
+    }
+  }, [isOpen])
 
   return (
     <ChakraMenu.Root
@@ -83,7 +101,7 @@ const Menu = ({
     >
       <ChakraMenu.Trigger css={menuStyles(theme, fontSize)} asChild>
         {customTrigger || (
-          <button type='button'>
+          <button type='button' ref={triggerRef}>
             {label}
             <ChevronDownIcon
               marginLeft='0.375rem'
@@ -101,6 +119,7 @@ const Menu = ({
             role='menu'
             aria-label={label || 'Menu'}
           >
+            <div css={menuArrowStyles} />
             {items?.map((item, idx) => {
               if (item.submenu) {
                 const [submenuOpen, setSubmenuOpen] = useState(false)

--- a/src/components/Forms/Actions/Menu/styled.ts
+++ b/src/components/Forms/Actions/Menu/styled.ts
@@ -213,6 +213,10 @@ export const menuItemLabelContentStyles = css`
   }
 `
 
+export const menuItemLabelCheckedStyles = css`
+  font-weight: 700;
+`
+
 export const menuItemGroupLabelStyles = css`
   font-size: ${getThemedFontSize(300)};
   line-height: ${getThemedLineHeight(500)};

--- a/src/components/Forms/Actions/Menu/styled.ts
+++ b/src/components/Forms/Actions/Menu/styled.ts
@@ -35,6 +35,36 @@ export const menuStyles = (theme?: 'light' | 'dark', fontSize?: string) => css`
   }
 `
 
+export const menuArrowStyles = css`
+  position: absolute;
+  left: 1rem;
+  width: 1rem;
+  height: 1rem;
+  background: white;
+  transform: rotate(45deg);
+  z-index: 2;
+
+  border-left: ${getThemedBorderWidth(100)} solid
+    ${getThemedColor('neutral', 600)};
+  border-top: ${getThemedBorderWidth(100)} solid
+    ${getThemedColor('neutral', 600)};
+
+  top: -0.5rem;
+
+  [data-placement*='top'] & {
+    top: auto;
+    bottom: -0.5rem;
+
+    border-top: none;
+    border-left: none;
+
+    border-right: ${getThemedBorderWidth(100)} solid
+      ${getThemedColor('neutral', 600)};
+    border-bottom: ${getThemedBorderWidth(100)} solid
+      ${getThemedColor('neutral', 600)};
+  }
+`
+
 export const menuContentStyles = css`
   width: 14rem;
   border: ${getThemedBorderWidth(100)} solid ${getThemedColor('neutral', 600)};

--- a/src/components/Forms/Actions/Menu/types.ts
+++ b/src/components/Forms/Actions/Menu/types.ts
@@ -23,4 +23,8 @@ export type MenuProps = {
   }[]
   onSelect?: (value: string) => void
   customTrigger?: React.ReactNode
+  /** When set, enables checkable items. 'multiple' allows many items checked at once; 'radio' allows only one. Omit (default) for a non-selectable menu. */
+  selectionMode?: 'multiple' | 'radio'
+  /** Values that are checked by default on first render. */
+  defaultSelectedValues?: string[]
 }


### PR DESCRIPTION
What
Add checkable item support to the [Menu](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) component, with multiple and radio selection modes.

Why
Some use cases require a menu that acts as a selector (e.g. language picker, view mode toggle). Previously the [Menu](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) component only supported fire-and-forget actions with no persistent checked state.

Changes
[types.ts](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html)

Added [selectionMode?: 'multiple' | 'radio'](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) — when omitted (default), the menu behaves as before with no selection state.
Added [defaultSelectedValues?: string[]](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) — pre-checked values on first render.
[index.tsx](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html)

Internal [selectedValues: Set<string>](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) state tracks checked items.
[onSelect](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) handler toggles (multiple) or replaces (radio) the selection.
[isChecked](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) is only computed when [selectionMode](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) is set, so existing non-selectable menus are unaffected.
[MenuItem.tsx](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) / [styled.ts](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html)

When [isChecked](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) is true: label renders in bold (font-weight: 700) and a [CheckIcon](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) appears at the trailing edge — matching the Figma design.
Added [menuItemLabelCheckedStyles](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) token-based style.
[Menu.stories.tsx](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html)

Added [MultipleSelection](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) story (Language picker, Spanish pre-checked).
Added [RadioSelection](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) story (View mode, Map pre-checked).
Added [selectionMode](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) and [defaultSelectedValues](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) to [argTypes](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html).
[MenuDemo.tsx](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html)


Added "Language (multiple)" and "View mode (radio)" demo examples.
<img width="377" height="290" alt="Screenshot 2026-06-01 at 4 38 57 p m" src="https://github.com/user-attachments/assets/a069de7a-8c43-4546-a2a3-f13026b669ce" />
