### PR TITLE
DS-303 - Table update - Fix column prop

### DIFF
--- a/src/components/DataDisplay/Table/README.md
+++ b/src/components/DataDisplay/Table/README.md
@@ -20,11 +20,13 @@ const columns = [
     key: 'name',
     label: 'Name',
     sortable: true,
+    sticky: true,
   },
   {
     key: 'email',
     label: 'Email',
     sortable: true,
+    sticky: true,
   },
   {
     key: 'age',
@@ -37,10 +39,13 @@ const columns = [
 ### Render Row
 
 ```tsx
-const renderRow = (rowData: RowData) => (
+const renderRow = (
+  rowData: RowData,
+  context?: { getCellProps?: (columnKey: string) => Record<string, any> },
+) => (
   <TableRow>
-    <TableCell>{rowData.name}</TableCell>
-    <TableCell>{rowData.email}</TableCell>
+    <TableCell {...context?.getCellProps?.('name')}>{rowData.name}</TableCell>
+    <TableCell {...context?.getCellProps?.('email')}>{rowData.email}</TableCell>
     <TableCell>{rowData.age}</TableCell>
   </TableRow>
 )
@@ -103,9 +108,16 @@ type TableProps = {
     key: string
     label: string
     sortable?: boolean
+    sticky?: boolean | 'start' | 'end'
   }[]
   data?: any
-  renderRow: any
+  renderRow: (
+    row: any,
+    context?: {
+      className?: string
+      getCellProps: (columnKey: string) => Record<string, any>
+    },
+  ) => ReactNode
   striped?: boolean
   stickyHeader?: boolean
   selectable?: boolean
@@ -126,6 +138,31 @@ type TableProps = {
   /** When set, the table scrolls vertically within this height and horizontally within the containers width while pagination stays fixed */
   height?: string
 }
+```
+
+## Sticky columns
+
+Mark one or more columns with `sticky` and use `context.getCellProps(columnKey)` in `renderRow` for matching body cells.
+
+```tsx
+const columns = [
+  { key: 'name', label: 'Name', sticky: true },
+  { key: 'email', label: 'Email', sticky: true },
+  { key: 'age', label: 'Age' },
+  { key: 'country', label: 'Country' },
+]
+
+const renderRow = (
+  rowData: RowData,
+  context?: { getCellProps?: (columnKey: string) => Record<string, any> },
+) => (
+  <TableRow>
+    <TableCell {...context?.getCellProps?.('name')}>{rowData.name}</TableCell>
+    <TableCell {...context?.getCellProps?.('email')}>{rowData.email}</TableCell>
+    <TableCell>{rowData.age}</TableCell>
+    <TableCell>{rowData.country}</TableCell>
+  </TableRow>
+)
 ```
 
 ## Selectable

--- a/src/components/DataDisplay/Table/README.md
+++ b/src/components/DataDisplay/Table/README.md
@@ -19,12 +19,14 @@ const columns = [
   {
     key: 'name',
     label: 'Name',
+    width: '12rem',
     sortable: true,
     sticky: true,
   },
   {
     key: 'email',
     label: 'Email',
+    width: '18rem',
     sortable: true,
     sticky: true,
   },
@@ -108,7 +110,8 @@ type TableProps = {
     key: string
     label: string
     sortable?: boolean
-    sticky?: boolean | 'start' | 'end'
+    width?: string
+    sticky?: boolean
   }[]
   data?: any
   renderRow: (
@@ -146,8 +149,8 @@ Mark one or more columns with `sticky` and use `context.getCellProps(columnKey)`
 
 ```tsx
 const columns = [
-  { key: 'name', label: 'Name', sticky: true },
-  { key: 'email', label: 'Email', sticky: true },
+  { key: 'name', label: 'Name', width: '12rem', sticky: true },
+  { key: 'email', label: 'Email', width: '18rem', sticky: true },
   { key: 'age', label: 'Age' },
   { key: 'country', label: 'Country' },
 ]

--- a/src/components/DataDisplay/Table/Table.stories.tsx
+++ b/src/components/DataDisplay/Table/Table.stories.tsx
@@ -313,6 +313,10 @@ type WideRowData = RowData & {
   status: string
 }
 
+type RenderRowContext = {
+  getCellProps?: (columnKey: string) => Record<string, any>
+}
+
 const wideData: WideRowData[] = Array(100)
   .fill(0)
   .map((_, i) => ({
@@ -326,6 +330,17 @@ const wideData: WideRowData[] = Array(100)
     department: ['Engineering', 'Design', 'Product', 'Marketing'][i % 4],
     status: ['Active', 'Inactive', 'Pending'][i % 3],
   }))
+
+const stickyWideColumns = [
+  { key: 'name', label: 'Name', sortable: true, sticky: true },
+  { key: 'email', label: 'Email', sortable: true, sticky: false },
+  { key: 'age', label: 'Age', sortable: true },
+  { key: 'country', label: 'Country', sortable: true },
+  { key: 'city', label: 'City', sortable: true },
+  { key: 'role', label: 'Role', sortable: true },
+  { key: 'department', label: 'Department', sortable: true },
+  { key: 'status', label: 'Status', sortable: true },
+]
 
 export const ScrollableTable = {
   args: {
@@ -411,4 +426,93 @@ export const ScrollableTable = {
       </div>
     )
   },
+}
+
+const makeStickyStoryRender =
+  (withStickyHeader: boolean) =>
+  (args: StoryObj<typeof TableStory>['args']) => {
+    const totalItems = 100
+    const [currentPage, setCurrentPage] = useState(1)
+    const [pageSize, setPageSize] = useState(10)
+    const [sortColumn, setSortColumn] = useState<{
+      key: string
+      order: string
+    }>({ key: '', order: '' })
+
+    const startRange = (currentPage - 1) * pageSize
+    const endRange = startRange + pageSize
+
+    let fullData = [...wideData]
+
+    if (sortColumn && sortColumn.key !== '') {
+      const { key, order } = sortColumn
+      const isDesc = order === 'desc'
+
+      fullData = fullData.sort((a, b) => {
+        const aVal = (a as any)[key]
+        const bVal = (b as any)[key]
+
+        if (typeof aVal === 'string' && typeof bVal === 'string') {
+          return isDesc ? aVal.localeCompare(bVal) : bVal.localeCompare(aVal)
+        }
+
+        return isDesc
+          ? (aVal as number) - (bVal as number)
+          : (bVal as number) - (aVal as number)
+      })
+    }
+
+    const dataByPage = fullData.slice(startRange, endRange)
+
+    const renderRow = (rowData: WideRowData, context?: RenderRowContext) => (
+      <TableRow>
+        <TableCell {...context?.getCellProps?.('name')}>
+          {rowData.name}
+        </TableCell>
+        <TableCell {...context?.getCellProps?.('email')}>
+          {rowData.email}
+        </TableCell>
+        <TableCell>{rowData.age}</TableCell>
+        <TableCell>{rowData.country}</TableCell>
+        <TableCell>{rowData.city}</TableCell>
+        <TableCell>{rowData.role}</TableCell>
+        <TableCell>{rowData.department}</TableCell>
+        <TableCell>{rowData.status}</TableCell>
+      </TableRow>
+    )
+
+    return (
+      <div style={{ padding: '1.5rem', maxWidth: '800px' }}>
+        <TableStory
+          {...args}
+          columns={stickyWideColumns}
+          data={dataByPage}
+          renderRow={renderRow}
+          onSortColumn={setSortColumn}
+          onPageSizeChange={setPageSize}
+          onPageChange={setCurrentPage}
+          stickyHeader={withStickyHeader}
+          pagination={{
+            totalItems,
+            currentPage,
+            pageSize,
+            showItemCount: true,
+          }}
+        />
+      </div>
+    )
+  }
+
+export const StickyColumns = {
+  name: 'Sticky Columns',
+  args: { height: '300px' },
+  parameters: { layout: 'fullscreen' },
+  render: makeStickyStoryRender(false),
+}
+
+export const StickyColumnsAndHeader = {
+  name: 'Sticky Columns + Sticky Header',
+  args: { height: '300px', stickyHeader: true },
+  parameters: { layout: 'fullscreen' },
+  render: makeStickyStoryRender(true),
 }

--- a/src/components/DataDisplay/Table/Table.stories.tsx
+++ b/src/components/DataDisplay/Table/Table.stories.tsx
@@ -429,8 +429,7 @@ export const ScrollableTable = {
 }
 
 const makeStickyStoryRender =
-  (withStickyHeader: boolean) =>
-  (args: StoryObj<typeof TableStory>['args']) => {
+  () => (args: StoryObj<typeof TableStory>['args']) => {
     const totalItems = 100
     const [currentPage, setCurrentPage] = useState(1)
     const [pageSize, setPageSize] = useState(10)
@@ -491,7 +490,6 @@ const makeStickyStoryRender =
           onSortColumn={setSortColumn}
           onPageSizeChange={setPageSize}
           onPageChange={setCurrentPage}
-          stickyHeader={withStickyHeader}
           pagination={{
             totalItems,
             currentPage,
@@ -505,14 +503,173 @@ const makeStickyStoryRender =
 
 export const StickyColumns = {
   name: 'Sticky Columns',
-  args: { height: '300px' },
+  args: { height: '300px', stickyHeader: false },
   parameters: { layout: 'fullscreen' },
-  render: makeStickyStoryRender(false),
+  render: makeStickyStoryRender(),
 }
 
 export const StickyColumnsAndHeader = {
   name: 'Sticky Columns + Sticky Header',
   args: { height: '300px', stickyHeader: true },
   parameters: { layout: 'fullscreen' },
-  render: makeStickyStoryRender(true),
+  render: makeStickyStoryRender(),
+}
+
+type CustomizableColumnsArgs = StoryObj<typeof TableStory>['args'] & {
+  nameWidth: string
+  emailWidth: string
+  ageWidth: string
+  nameSticky: boolean
+  emailSticky: boolean
+}
+
+export const CustomizableColumnWidths = {
+  name: 'Customizable Column Widths',
+  args: {
+    height: '300px',
+    stickyHeader: true,
+    nameWidth: '12rem',
+    emailWidth: '18rem',
+    ageWidth: '8rem',
+    nameSticky: true,
+    emailSticky: false,
+  },
+  argTypes: {
+    stickyHeader: {
+      control: { type: 'boolean' },
+    },
+    height: {
+      control: { type: 'text' },
+    },
+    nameWidth: {
+      control: { type: 'text' },
+      description: 'Width for Name column (e.g. 12rem, 180px, 20%).',
+    },
+    emailWidth: {
+      control: { type: 'text' },
+      description: 'Width for Email column (e.g. 18rem, 260px, 30%).',
+    },
+    ageWidth: {
+      control: { type: 'text' },
+      description: 'Width for Age column (e.g. 8rem, 100px).',
+    },
+    nameSticky: {
+      control: { type: 'boolean' },
+    },
+    emailSticky: {
+      control: { type: 'boolean' },
+    },
+  },
+  parameters: {
+    layout: 'fullscreen',
+    docs: {
+      description: {
+        story:
+          'Use controls to customize column widths and sticky behavior interactively.',
+      },
+    },
+  },
+  render: (args: CustomizableColumnsArgs) => {
+    const {
+      nameWidth,
+      emailWidth,
+      ageWidth,
+      nameSticky,
+      emailSticky,
+      ...tableArgs
+    } = args
+
+    const totalItems = 100
+    const [currentPage, setCurrentPage] = useState(1)
+    const [pageSize, setPageSize] = useState(10)
+    const [sortColumn, setSortColumn] = useState<{
+      key: string
+      order: string
+    }>({ key: '', order: '' })
+
+    const startRange = (currentPage - 1) * pageSize
+    const endRange = startRange + pageSize
+
+    let fullData = [...wideData]
+
+    if (sortColumn && sortColumn.key !== '') {
+      const { key, order } = sortColumn
+      const isDesc = order === 'desc'
+
+      fullData = fullData.sort((a, b) => {
+        const aVal = (a as any)[key]
+        const bVal = (b as any)[key]
+
+        if (typeof aVal === 'string' && typeof bVal === 'string') {
+          return isDesc ? aVal.localeCompare(bVal) : bVal.localeCompare(aVal)
+        }
+
+        return isDesc
+          ? (aVal as number) - (bVal as number)
+          : (bVal as number) - (aVal as number)
+      })
+    }
+
+    const dataByPage = fullData.slice(startRange, endRange)
+
+    const columnsWithControls = [
+      {
+        key: 'name',
+        label: 'Name',
+        sortable: true,
+        width: nameWidth,
+        sticky: nameSticky,
+      },
+      {
+        key: 'email',
+        label: 'Email',
+        sortable: true,
+        width: emailWidth,
+        sticky: emailSticky,
+      },
+      { key: 'age', label: 'Age', sortable: true, width: ageWidth },
+      { key: 'country', label: 'Country', sortable: true },
+      { key: 'city', label: 'City', sortable: true },
+      { key: 'role', label: 'Role', sortable: true },
+      { key: 'department', label: 'Department', sortable: true },
+      { key: 'status', label: 'Status', sortable: true },
+    ]
+
+    const renderRow = (rowData: WideRowData, context?: RenderRowContext) => (
+      <TableRow>
+        <TableCell {...context?.getCellProps?.('name')}>
+          {rowData.name}
+        </TableCell>
+        <TableCell {...context?.getCellProps?.('email')}>
+          {rowData.email}
+        </TableCell>
+        <TableCell {...context?.getCellProps?.('age')}>{rowData.age}</TableCell>
+        <TableCell>{rowData.country}</TableCell>
+        <TableCell>{rowData.city}</TableCell>
+        <TableCell>{rowData.role}</TableCell>
+        <TableCell>{rowData.department}</TableCell>
+        <TableCell>{rowData.status}</TableCell>
+      </TableRow>
+    )
+
+    return (
+      <div style={{ padding: '1.5rem', maxWidth: '900px' }}>
+        <TableStory
+          {...tableArgs}
+          columns={columnsWithControls}
+          data={dataByPage}
+          renderRow={renderRow}
+          onSortColumn={setSortColumn}
+          onPageSizeChange={setPageSize}
+          onPageChange={setCurrentPage}
+          pagination={{
+            totalItems,
+            currentPage,
+            pageSize,
+            showItemCount: true,
+          }}
+        />
+      </div>
+    )
+  },
 }

--- a/src/components/DataDisplay/Table/TableDemo.tsx
+++ b/src/components/DataDisplay/Table/TableDemo.tsx
@@ -36,6 +36,44 @@ const data: Record<string, any>[] = Array(100)
     age: Math.round(Math.random() * 100),
   }))
 
+const stickyColumns = [
+  { key: 'name', label: 'Name', sortable: true, sticky: true },
+  { key: 'email', label: 'Email', sortable: true, sticky: true },
+  { key: 'age', label: 'Age', sortable: true },
+  { key: 'country', label: 'Country', sortable: true },
+  { key: 'city', label: 'City', sortable: true },
+  { key: 'role', label: 'Role', sortable: true },
+  { key: 'department', label: 'Department', sortable: true },
+  { key: 'status', label: 'Status', sortable: true },
+]
+
+type StickyRowData = RowData & {
+  country: string
+  city: string
+  role: string
+  department: string
+  status: string
+}
+
+const stickyData: StickyRowData[] = Array(100)
+  .fill(0)
+  .map((_, i) => ({
+    id: i,
+    name: `Item ${i + 1}`,
+    email: `email${i + 1}@example.com`,
+    age: Math.round(Math.random() * 100),
+    country: `Country ${(i % 5) + 1}`,
+    city: `City ${(i % 8) + 1}`,
+    role: ['Admin', 'Editor', 'Viewer'][i % 3],
+    department: ['Engineering', 'Design', 'Product', 'Marketing'][i % 4],
+    status: ['Active', 'Inactive', 'Pending'][i % 3],
+  }))
+
+type RenderRowContext = {
+  className?: string
+  getCellProps?: (columnKey: string) => Record<string, any>
+}
+
 const TableDemo = () => {
   const totalItems = 100
   const [currentPage, setCurrentPage] = useState(1)
@@ -71,6 +109,7 @@ const TableDemo = () => {
   }
 
   const dataByPage = fullData.slice(startRange, endRange) as RowData[]
+  const stickyDataByPage = stickyData.slice(startRange, endRange)
 
   const renderRow = (rowData: RowData) => (
     <TableRow>
@@ -121,6 +160,19 @@ const TableDemo = () => {
       setSelectedRows([])
     }
   }
+
+  const stickyRenderRow = (rowData: StickyRowData, context?: RenderRowContext) => (
+    <TableRow>
+      <TableCell {...context?.getCellProps?.('name')}>{rowData.name}</TableCell>
+      <TableCell {...context?.getCellProps?.('email')}>{rowData.email}</TableCell>
+      <TableCell>{rowData.age}</TableCell>
+      <TableCell>{rowData.country}</TableCell>
+      <TableCell>{rowData.city}</TableCell>
+      <TableCell>{rowData.role}</TableCell>
+      <TableCell>{rowData.department}</TableCell>
+      <TableCell>{rowData.status}</TableCell>
+    </TableRow>
+  )
 
   return (
     <DemoWrapper title='Table'>
@@ -179,6 +231,47 @@ const TableDemo = () => {
             onAllItemsSelected={onAllItemsSelected}
             selectedRows={selectedRows}
             selectable
+          />
+        </div>
+        <div style={{ width: '100%', maxWidth: '56.25rem' }}>
+          <p style={{ marginBottom: '0.5rem', fontWeight: 600 }}>
+            Sticky Columns
+          </p>
+          <Table
+            columns={stickyColumns}
+            data={stickyDataByPage}
+            renderRow={stickyRenderRow}
+            onSortColumn={setSortColumn}
+            onPageSizeChange={setPageSize}
+            onPageChange={setCurrentPage}
+            pagination={{
+              totalItems,
+              currentPage,
+              pageSize,
+              showItemCount: true,
+            }}
+            height='18.75rem'
+          />
+        </div>
+        <div style={{ width: '100%', maxWidth: '56.25rem' }}>
+          <p style={{ marginBottom: '0.5rem', fontWeight: 600 }}>
+            Sticky Columns + Sticky Header
+          </p>
+          <Table
+            columns={stickyColumns}
+            data={stickyDataByPage}
+            renderRow={stickyRenderRow}
+            onSortColumn={setSortColumn}
+            onPageSizeChange={setPageSize}
+            onPageChange={setCurrentPage}
+            pagination={{
+              totalItems,
+              currentPage,
+              pageSize,
+              showItemCount: true,
+            }}
+            stickyHeader
+            height='18.75rem'
           />
         </div>
       </div>

--- a/src/components/DataDisplay/Table/TableDemo.tsx
+++ b/src/components/DataDisplay/Table/TableDemo.tsx
@@ -161,10 +161,15 @@ const TableDemo = () => {
     }
   }
 
-  const stickyRenderRow = (rowData: StickyRowData, context?: RenderRowContext) => (
+  const stickyRenderRow = (
+    rowData: StickyRowData,
+    context?: RenderRowContext,
+  ) => (
     <TableRow>
       <TableCell {...context?.getCellProps?.('name')}>{rowData.name}</TableCell>
-      <TableCell {...context?.getCellProps?.('email')}>{rowData.email}</TableCell>
+      <TableCell {...context?.getCellProps?.('email')}>
+        {rowData.email}
+      </TableCell>
       <TableCell>{rowData.age}</TableCell>
       <TableCell>{rowData.country}</TableCell>
       <TableCell>{rowData.city}</TableCell>

--- a/src/components/DataDisplay/Table/index.tsx
+++ b/src/components/DataDisplay/Table/index.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable react/no-unknown-property */
 /** @jsxImportSource @emotion/react */
 
-import React, { useCallback, useEffect, useRef, useState } from 'react'
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { Table as ChakraTable, Spinner } from '@chakra-ui/react'
 import { TableColumn, TableProps } from './types'
 import Pagination from '../../Navigation/Pagination'
@@ -68,6 +68,14 @@ const Table = ({
 
   const allChecked = selectedRows?.length === data?.length
   const indeterminate = selectedRows && selectedRows.length > 0 && !allChecked
+  const columnsByKey = useMemo(
+    () =>
+      columns.reduce<Record<string, TableColumn>>((acc, column) => {
+        acc[column.key] = column
+        return acc
+      }, {}),
+    [columns],
+  )
   const stickyColumnKeys = columns
     .filter((column) => column.sticky)
     .map((column) => column.key)
@@ -104,22 +112,39 @@ const Table = ({
     }
   }, [calculateStickyPositions])
 
+  const getColumnWidthProps = (columnKey: string) => {
+    const width = columnsByKey[columnKey]?.width
+
+    if (!width) {
+      return {}
+    }
+
+    return {
+      width,
+      minWidth: width,
+    }
+  }
+
   const getStickyProps = (column: TableColumn) => {
     const offset = stickyOffsets[column.key]
     if (offset === undefined) return {}
     return {
       'data-sticky': 'start',
-      'data-sticky-last': column.key === lastStickyColumnKey ? 'true' : undefined,
+      'data-sticky-last':
+        column.key === lastStickyColumnKey ? 'true' : undefined,
       left: `${offset}px`,
     }
   }
 
   const getCellProps = (columnKey: string) => {
+    const widthProps = getColumnWidthProps(columnKey)
     const offset = stickyOffsets[columnKey]
-    if (offset === undefined) return {}
+    if (offset === undefined) return widthProps
     return {
+      ...widthProps,
       'data-sticky': 'start',
-      'data-sticky-last': columnKey === lastStickyColumnKey ? 'true' : undefined,
+      'data-sticky-last':
+        columnKey === lastStickyColumnKey ? 'true' : undefined,
       left: `${offset}px`,
     }
   }
@@ -156,6 +181,7 @@ const Table = ({
                   ref={(node: HTMLTableCellElement | null) => {
                     headerCellRefs.current[column.key] = node
                   }}
+                  {...getColumnWidthProps(column.key)}
                   role={column.sortable ? 'columnheader' : undefined}
                   aria-sort={
                     // eslint-disable-next-line no-nested-ternary
@@ -164,8 +190,8 @@ const Table = ({
                       : column.sortable && sortColumn.order === 'desc'
                         ? 'descending'
                         : undefined
-                    }
-                    {...getStickyProps(column)}
+                  }
+                  {...getStickyProps(column)}
                 >
                   <div css={tableHeaderLabelStyles}>
                     {column.label}

--- a/src/components/DataDisplay/Table/index.tsx
+++ b/src/components/DataDisplay/Table/index.tsx
@@ -1,9 +1,9 @@
 /* eslint-disable react/no-unknown-property */
 /** @jsxImportSource @emotion/react */
 
-import React, { useState } from 'react'
+import React, { useCallback, useEffect, useRef, useState } from 'react'
 import { Table as ChakraTable, Spinner } from '@chakra-ui/react'
-import { TableProps } from './types'
+import { TableColumn, TableProps } from './types'
 import Pagination from '../../Navigation/Pagination'
 import {
   tableContainerStyles,
@@ -47,6 +47,8 @@ const Table = ({
     key: '',
     order: '',
   })
+  const headerCellRefs = useRef<Record<string, HTMLTableCellElement | null>>({})
+  const [stickyOffsets, setStickyOffsets] = useState<Record<string, number>>({})
 
   const {
     totalItems = data.length,
@@ -66,12 +68,67 @@ const Table = ({
 
   const allChecked = selectedRows?.length === data?.length
   const indeterminate = selectedRows && selectedRows.length > 0 && !allChecked
+  const stickyColumnKeys = columns
+    .filter((column) => column.sticky)
+    .map((column) => column.key)
+  const lastStickyColumnKey =
+    stickyColumnKeys.length > 0
+      ? stickyColumnKeys[stickyColumnKeys.length - 1]
+      : undefined
+
+  const calculateStickyPositions = useCallback(() => {
+    const nextOffsets: Record<string, number> = {}
+    let offset = 0
+    columns
+      .filter((column) => column.sticky)
+      .forEach((column) => {
+        nextOffsets[column.key] = offset
+        offset += headerCellRefs.current[column.key]?.offsetWidth || 0
+      })
+    setStickyOffsets(nextOffsets)
+  }, [columns])
+
+  useEffect(() => {
+    calculateStickyPositions()
+  }, [calculateStickyPositions, data.length])
+
+  useEffect(() => {
+    const onResize = () => {
+      calculateStickyPositions()
+    }
+
+    window.addEventListener('resize', onResize)
+
+    return () => {
+      window.removeEventListener('resize', onResize)
+    }
+  }, [calculateStickyPositions])
+
+  const getStickyProps = (column: TableColumn) => {
+    const offset = stickyOffsets[column.key]
+    if (offset === undefined) return {}
+    return {
+      'data-sticky': 'start',
+      'data-sticky-last': column.key === lastStickyColumnKey ? 'true' : undefined,
+      left: `${offset}px`,
+    }
+  }
+
+  const getCellProps = (columnKey: string) => {
+    const offset = stickyOffsets[columnKey]
+    if (offset === undefined) return {}
+    return {
+      'data-sticky': 'start',
+      'data-sticky-last': columnKey === lastStickyColumnKey ? 'true' : undefined,
+      left: `${offset}px`,
+    }
+  }
 
   return (
     <div>
       <div css={height ? tableScrollContainerStyles(height) : undefined}>
         <ChakraTable.Root
-          css={tableContainerStyles(variant)}
+          css={tableContainerStyles(variant, stickyHeader)}
           striped={striped}
           stickyHeader={stickyHeader}
           interactive
@@ -96,6 +153,9 @@ const Table = ({
               {columns.map((column) => (
                 <ChakraTable.ColumnHeader
                   key={column.key}
+                  ref={(node: HTMLTableCellElement | null) => {
+                    headerCellRefs.current[column.key] = node
+                  }}
                   role={column.sortable ? 'columnheader' : undefined}
                   aria-sort={
                     // eslint-disable-next-line no-nested-ternary
@@ -104,7 +164,8 @@ const Table = ({
                       : column.sortable && sortColumn.order === 'desc'
                         ? 'descending'
                         : undefined
-                  }
+                    }
+                    {...getStickyProps(column)}
                 >
                   <div css={tableHeaderLabelStyles}>
                     {column.label}
@@ -148,6 +209,7 @@ const Table = ({
                   )
                     ? 'selected'
                     : undefined,
+                  getCellProps,
                 })}
               </React.Fragment>
             ))}

--- a/src/components/DataDisplay/Table/styles.ts
+++ b/src/components/DataDisplay/Table/styles.ts
@@ -8,7 +8,10 @@ import {
   getThemedSpacing,
 } from '../../../lib/theme'
 
-export const tableContainerStyles = (variant: string) => css`
+export const tableContainerStyles = (
+  variant: string,
+  stickyHeader?: boolean,
+) => css`
   border: ${variant === 'full-width'
     ? 'none'
     : `${getThemedBorderWidth(100)} solid ${getThemedColor('neutral', 300)}`};
@@ -16,6 +19,53 @@ export const tableContainerStyles = (variant: string) => css`
   box-shadow: ${variant === 'full-width'
     ? 'none'
     : `0 0 0 0.0625rem ${getThemedColor('neutral', 300)}`};
+
+  [data-sticky] {
+    position: sticky;
+    background-color: ${getThemedColor('neutral', 100)};
+
+    &::after {
+      content: '';
+      position: absolute;
+      pointer-events: none;
+      top: 0;
+      bottom: -0.0625rem;
+      width: ${getThemedSpacing(800)};
+    }
+  }
+
+  th[data-sticky] {
+    background-color: ${variant === 'full-width'
+      ? getThemedColor('neutral', 100)
+      : getThemedColor('neutral', 200)};
+    z-index: ${stickyHeader ? 4 : 2};
+    top: ${stickyHeader ? '0' : 'auto'};
+  }
+
+  thead {
+    z-index: ${stickyHeader ? 3 : 'auto'};
+  }
+
+  [data-sticky='start']::after {
+    content: none;
+  }
+
+  [data-sticky-last='true']::after {
+    content: '';
+    position: absolute;
+    pointer-events: none;
+    top: 0;
+    bottom: -0.0625rem;
+    inset-inline-end: 0;
+    translate: 100% 0;
+    width: 0.0625rem;
+    background: ${getThemedColor('neutral', 400)};
+    box-shadow: 0.0625rem 0 0.125rem 0 rgba(0, 0, 0, 0.2);
+  }
+
+  [data-sticky-last='true'] {
+    border-inline-end: 0.0625rem solid ${getThemedColor('neutral', 400)};
+  }
 `
 
 export const tableHeaderContainerStyles = (variant: string) => css`
@@ -94,11 +144,19 @@ export const tableBodyStyles = css`
 
     :hover {
       background-color: ${getThemedColor('neutral', 200)};
+
+      td[data-sticky] {
+        background-color: ${getThemedColor('neutral', 200)};
+      }
     }
 
     &.selected {
       background-color: ${getThemedColor('primary', 100)} !important;
       border-bottom: 0.125rem solid ${getThemedColor('primary', 700)} !important;
+
+      td[data-sticky] {
+        background-color: ${getThemedColor('primary', 100)};
+      }
     }
   }
 `

--- a/src/components/DataDisplay/Table/types.ts
+++ b/src/components/DataDisplay/Table/types.ts
@@ -1,15 +1,25 @@
+import type { ReactNode } from 'react'
 import type { TableLabels } from '../../../lib/i18n/types'
 
 export type { TableLabels }
 
+export type TableColumn = {
+  key: string
+  label: string
+  sortable?: boolean
+  /** When true, this column sticks to the left during horizontal scroll. */
+  sticky?: boolean
+}
+
+export type TableRenderRowContext = {
+  className?: string
+  getCellProps: (columnKey: string) => Record<string, any>
+}
+
 export type TableProps = {
-  columns: {
-    key: string
-    label: string
-    sortable?: boolean
-  }[]
+  columns: TableColumn[]
   data?: any
-  renderRow: any
+  renderRow: (row: any, context?: TableRenderRowContext) => ReactNode
   striped?: boolean
   stickyHeader?: boolean
   selectable?: boolean

--- a/src/components/DataDisplay/Table/types.ts
+++ b/src/components/DataDisplay/Table/types.ts
@@ -7,6 +7,7 @@ export type TableColumn = {
   key: string
   label: string
   sortable?: boolean
+  width?: string
   /** When true, this column sticks to the left during horizontal scroll. */
   sticky?: boolean
 }


### PR DESCRIPTION
What
This pull request fixes and extends the Table component to consistently support sticky columns (header + body), as well as enabling per-column width and exposing utilities to apply these styles to each cell in the renderRow.

Why
We needed to resolve the issue of fixed/misaligned columns in tables with horizontal scrolling (DS-303) and improve the experience with wide tables, especially when combined with sticky headers, row selection, and pagination.

Changes
Column configuration was typed with new options:
optional per-column width.
optional per-column sticky.
The renderRow component was typed with an optional context that includes:
className.
getCellProps(columnKey) to apply sticky width/position to body cells.

In Table:
References were added to headers to measure actual widths.
The cumulative offset of sticky columns is calculated.
Offsets are recalculated on resizes and when data changes.

Sticky and width props are applied to the ColumnHeader and exposed to the body via getCellProps.

In styles:
New rules for [data-sticky] and visual separation of the last sticky column.
Adjustments to z-index and top for compatibility with stickyHeader.
The correct background color is maintained on hover/selected for sticky cells.

Storybook:
New stories for Sticky Columns.
Sticky Columns + Sticky Header.
Story with controls for widths and sticky behavior per column.

Demo:
Real-world examples of sticky columns have been added.


README:
The use of sticky + width has been documented.
An example of renderingRow using getCellProps has been added.