### PR TITLE
[DS-309] - [DS-314] - [DS-312] - minor ui updates

### DIFF
--- a/src/components/DataDisplay/ItemCount/index.tsx
+++ b/src/components/DataDisplay/ItemCount/index.tsx
@@ -31,7 +31,7 @@ const ItemCount = ({
 
   return (
     <div css={itemCountContainerStyles}>
-      <div css={itemCountPerPageContainerStyles}>
+      <div css={itemCountPerPageContainerStyles(showItemCountText)}>
         <div style={{ width: '5rem' }}>
           <Select
             defaultValue={[`${pageSize}`]}

--- a/src/components/DataDisplay/ItemCount/styles.ts
+++ b/src/components/DataDisplay/ItemCount/styles.ts
@@ -11,11 +11,13 @@ export const itemCountContainerStyles = css`
   flex-direction: column;
 `
 
-export const itemCountPerPageContainerStyles = css`
+export const itemCountPerPageContainerStyles = (
+  showItemCountText?: boolean,
+) => css`
   display: flex;
   gap: ${getThemedSpacing(400)};
   align-items: center;
-  margin-bottom: ${getThemedSpacing(300)};
+  margin-bottom: ${showItemCountText ? getThemedSpacing(300) : 0};
 
   .ds-select-input-container {
     margin-bottom: 0rem;

--- a/src/components/Status/InlineMessage/styled.ts
+++ b/src/components/Status/InlineMessage/styled.ts
@@ -12,11 +12,11 @@ export const defaultInlineMessageStyles = (
   size: string,
   isButtonRight?: boolean,
 ) => {
-  let maxWidth = '14.625rem'
+  let maxWidth = '14.875rem'
   if (size === 'full-width') {
     maxWidth = '100%'
   } else if (size === 'large') {
-    maxWidth = '20rem'
+    maxWidth = '22.875rem'
   }
 
   return css`
@@ -44,7 +44,7 @@ export const inlineMessageHeaderStyles = css`
   gap: ${getThemedSpacing(200)};
 
   svg {
-    margin-top: 0.375rem;
+    margin-top: 0.1875rem;
   }
 `
 

--- a/src/components/Status/Toast/Toast.stories.tsx
+++ b/src/components/Status/Toast/Toast.stories.tsx
@@ -368,7 +368,8 @@ export const OnClose: Story = {
             type: 'success',
             placement: 'bottom-end',
             closable: true,
-            onClose: () => console.log('Closed'),
+            // eslint-disable-next-line no-alert
+            onClose: () => alert('Closed'),
           })
         }
       />


### PR DESCRIPTION
  ## What

  This PR addresses layout alignment, spacing, and testing feedback across  ItemCount ,              
  InlineMessage , and  Toast  components.

  ## Why

  These updates resolve visual spacing issues (removing extra bottom padding when text is hidden on  
  ItemCount ), adjust layout boundaries and vertical alignment for  InlineMessage  headers, and
  provide a clear visual callback via  alert  when validating the toast close interaction in
  Storybook.

  ## Changes

  ###  ItemCount  Layout Spacing

  • Updated  itemCountPerPageContainerStyles  in styles.ts and index.tsx to only apply a
  bottom margin of  300  tokens if the  showItemCountText  prop is active.


  ###  InlineMessage  UI Adjustments

  • Increased  maxWidth  in styled.ts to prevent premature wrapping of message content:
      • Default size max-width: increased from  14.625rem  to  14.875rem .
      • Large size max-width: increased from  20rem  to  22.875rem .
  • Fine-tuned the vertical alignment of the header icon by changing the SVG's  margin-top  from  0. 
  375rem  to  0.1875rem .

  ###  Toast  Storybook Validation

  • Modified the  OnClose  story in Toast.stories.tsx to trigger a browser  alert  rather than a
console.log, facilitating easier verification of the callback during manual story testing.