### PR TITLE
Table component refactor

### DIFF
--- a/src/components/DataDisplay/Table/README.md
+++ b/src/components/DataDisplay/Table/README.md
@@ -12,6 +12,78 @@ import { Table } from '@worldresources/wri-design-systems'
 
 ## Usage
 
+### Simple (No `renderRow`)
+
+`Table` now renders rows by default from `columns + data`.
+Sorting is `auto` by default:
+
+- with `onSortColumn` => external sorting (parent controls data order)
+- without `onSortColumn` => internal sorting (Table sorts received data)
+
+```tsx
+const columns = [
+  { key: 'name', label: 'Name', sortable: true, width: '12rem', sticky: true },
+  { key: 'email', label: 'Email', sortable: true, width: '18rem' },
+  { key: 'age', label: 'Age', sortable: true, width: '8rem' },
+]
+
+<Table
+  columns={columns}
+  data={dataByPage}
+  onPageSizeChange={setPageSize}
+  onPageChange={setCurrentPage}
+  pagination={{
+    totalItems,
+    currentPage,
+    pageSize,
+    showItemCount: true,
+  }}
+/>
+```
+
+### Override `onSortColumn` (External Sorting)
+
+Use `onSortColumn` when the parent must decide sort behavior (for example: server-side sorting, custom comparator rules, or coordinated sorting across views).
+
+```tsx
+const [sortColumn, setSortColumn] = useState<{ key: string; order: string }>({
+  key: '',
+  order: '',
+})
+
+const sortedData = useMemo(() => {
+  if (!sortColumn.key) return data
+
+  const { key, order } = sortColumn
+  const isAsc = order === 'asc'
+
+  return [...data].sort((a, b) => {
+    const aVal = a[key]
+    const bVal = b[key]
+
+    if (typeof aVal === 'string' && typeof bVal === 'string') {
+      return isAsc ? aVal.localeCompare(bVal) : bVal.localeCompare(aVal)
+    }
+
+    return isAsc ? (aVal as number) - (bVal as number) : (bVal as number) - (aVal as number)
+  })
+}, [data, sortColumn])
+
+<Table
+  columns={columns}
+  data={sortedData}
+  onSortColumn={setSortColumn}
+  onPageSizeChange={setPageSize}
+  onPageChange={setCurrentPage}
+  pagination={{
+    totalItems,
+    currentPage,
+    pageSize,
+    showItemCount: true,
+  }}
+/>
+```
+
 ### Columns
 
 ```tsx
@@ -40,6 +112,8 @@ const columns = [
 
 ### Render Row
 
+`renderRow` is optional and intended for advanced cases where you need full control of the row markup.
+
 ```tsx
 const renderRow = (
   rowData: RowData,
@@ -53,35 +127,20 @@ const renderRow = (
 )
 ```
 
+### Column Cell Overrides
+
+For lighter customization, prefer `columns[i].cell` over a full `renderRow`.
+
 ```tsx
-const selectableRenderRow = (rowData: RowData) => {
-  const handleOnRowSelected = ({ checked }: any) => {
-    setSelectedRows((current = [] as RowData[]) => {
-      if (checked) {
-        return [...current, rowData]
-      }
-
-      return current.filter((item) => item.id !== rowData.id)
-    })
-  }
-
-  return (
-    <TableRow
-      aria-selected={selectedRows?.some((item) => item.id === rowData.id)}
-    >
-      <TableCell>
-        <Checkbox
-          name={`checkbox-${rowData.id}`}
-          onCheckedChange={handleOnRowSelected}
-          checked={selectedRows?.some((item) => item.id === rowData.id)}
-        />
-      </TableCell>
-      <TableCell>{rowData.name}</TableCell>
-      <TableCell>{rowData.email}</TableCell>
-      <TableCell>{rowData.age}</TableCell>
-    </TableRow>
-  )
-}
+const columns = [
+  { key: 'name', label: 'Name', sortable: true, sticky: true },
+  {
+    key: 'age',
+    label: 'Age',
+    sortable: true,
+    cell: (row: RowData) => `${row.age} yrs`,
+  },
+]
 ```
 
 ```tsx
@@ -89,7 +148,6 @@ const selectableRenderRow = (rowData: RowData) => {
   columns={columns}
   data={dataByPage}
   renderRow={renderRow}
-  onSortColumn={setSortColumn}
   onPageSizeChange={setPageSize}
   onPageChange={setCurrentPage}
   pagination={{
@@ -117,6 +175,8 @@ type TableColumn = {
   label: string
   sortable?: boolean
   width?: string
+  /** Optional custom renderer for this column cell. */
+  cell?: (row: any) => ReactNode
   /** When true, this column sticks to the left during horizontal scroll. */
   sticky?: boolean
 }
@@ -129,7 +189,7 @@ type TableRenderRowContext = {
 type TableProps = {
   columns: TableColumn[]
   data?: any
-  renderRow: (row: any, context?: TableRenderRowContext) => ReactNode
+  renderRow?: (row: any, context?: TableRenderRowContext) => ReactNode
   striped?: boolean
   stickyHeader?: boolean
   selectable?: boolean
@@ -142,10 +202,12 @@ type TableProps = {
     showItemCount?: boolean
     showItemCountText?: boolean
   }
+  /** Optional override for external sorting mode. If omitted, Table sorts internally. */
   onSortColumn?: (sortColumn: { key: string; order: string }) => void
   onPageSizeChange?: (pageSize: number) => void
   onPageChange?: (page: number) => void
   onAllItemsSelected?: (checked: boolean) => void
+  onRowSelected?: (row: any, checked: boolean) => void
   loading?: boolean
   /** When set, the table scrolls vertically within this height and horizontally when it overflows its container (e.g. '400px', '60vh'). */
   height?: string
@@ -181,12 +243,12 @@ const renderRow = (
 
 ## Selectable
 
+With `selectable`, the default renderer automatically adds row checkboxes. Custom `renderRow` is not required.
+
 ```tsx
 <Table
   columns={columns}
   data={dataByPage}
-  renderRow={selectableRenderRow}
-  onSortColumn={setSortColumn}
   onPageSizeChange={setPageSize}
   onPageChange={setCurrentPage}
   pagination={{
@@ -196,8 +258,6 @@ const renderRow = (
     showItemCount: true,
     showItemCountText: true,
   }}
-  onAllItemsSelected={onAllItemsSelected}
-  selectedRows={selectedRows}
   selectable
 />
 ```
@@ -210,7 +270,6 @@ When `height` is set, the table body becomes scrollable (horizontally and vertic
 <Table
   columns={columns}
   data={dataByPage}
-  renderRow={renderRow}
   height='400px'
   pagination={{
     totalItems,

--- a/src/components/DataDisplay/Table/Table.stories.tsx
+++ b/src/components/DataDisplay/Table/Table.stories.tsx
@@ -4,7 +4,6 @@ import React, { useState } from 'react'
 import type { Meta, StoryObj } from '@storybook/react'
 import TableStory, { TableCell, TableRow } from '.'
 import { columns } from './TableDemo'
-import Checkbox from '../../Forms/Controls/Checkbox'
 
 const meta = {
   title: 'Data Display/Table',
@@ -54,47 +53,10 @@ export const Table = {
     const totalItems = 100
     const [currentPage, setCurrentPage] = useState(1)
     const [pageSize, setPageSize] = useState(10)
-    const [sortColumn, setSortColumn] = useState<{
-      key: string
-      order: string
-    }>({
-      key: '',
-      order: '',
-    })
 
     const startRange = (currentPage - 1) * pageSize
     const endRange = startRange + pageSize
-
-    let fullData = [...data]
-
-    if (sortColumn && sortColumn.key !== '') {
-      const { key, order } = sortColumn
-      const isDesc = order === 'desc'
-
-      fullData = fullData.sort((a, b) => {
-        if (typeof a[key] === 'string' && typeof b[key] === 'string') {
-          const newA = a[key]
-          const newB = b[key]
-
-          return isDesc ? newA.localeCompare(newB) : newB.localeCompare(newA)
-        }
-
-        const newA = a[key] as number
-        const newB = b[key] as number
-
-        return isDesc ? newA - newB : newB - newA
-      })
-    }
-
-    const dataByPage = fullData.slice(startRange, endRange) as RowData[]
-
-    const renderRow = (rowData: RowData) => (
-      <TableRow>
-        <TableCell>{rowData.name}</TableCell>
-        <TableCell>{rowData.email}</TableCell>
-        <TableCell>{rowData.age}</TableCell>
-      </TableRow>
-    )
+    const dataByPage = data.slice(startRange, endRange) as RowData[]
 
     return (
       <div style={{ width: '56.25rem' }}>
@@ -102,8 +64,6 @@ export const Table = {
           {...args}
           columns={columns}
           data={dataByPage}
-          renderRow={renderRow}
-          onSortColumn={setSortColumn}
           onPageSizeChange={setPageSize}
           onPageChange={setCurrentPage}
           pagination={{
@@ -127,47 +87,10 @@ export const FullWidthTable = {
     const totalItems = 100
     const [currentPage, setCurrentPage] = useState(1)
     const [pageSize, setPageSize] = useState(10)
-    const [sortColumn, setSortColumn] = useState<{
-      key: string
-      order: string
-    }>({
-      key: '',
-      order: '',
-    })
 
     const startRange = (currentPage - 1) * pageSize
     const endRange = startRange + pageSize
-
-    let fullData = [...data]
-
-    if (sortColumn && sortColumn.key !== '') {
-      const { key, order } = sortColumn
-      const isDesc = order === 'desc'
-
-      fullData = fullData.sort((a, b) => {
-        if (typeof a[key] === 'string' && typeof b[key] === 'string') {
-          const newA = a[key]
-          const newB = b[key]
-
-          return isDesc ? newA.localeCompare(newB) : newB.localeCompare(newA)
-        }
-
-        const newA = a[key] as number
-        const newB = b[key] as number
-
-        return isDesc ? newA - newB : newB - newA
-      })
-    }
-
-    const dataByPage = fullData.slice(startRange, endRange) as RowData[]
-
-    const renderRow = (rowData: RowData) => (
-      <TableRow>
-        <TableCell>{rowData.name}</TableCell>
-        <TableCell>{rowData.email}</TableCell>
-        <TableCell>{rowData.age}</TableCell>
-      </TableRow>
-    )
+    const dataByPage = data.slice(startRange, endRange) as RowData[]
 
     return (
       <div style={{ width: '56.25rem' }}>
@@ -175,8 +98,6 @@ export const FullWidthTable = {
           {...args}
           columns={columns}
           data={dataByPage}
-          renderRow={renderRow}
-          onSortColumn={setSortColumn}
           onPageSizeChange={setPageSize}
           onPageChange={setCurrentPage}
           pagination={{
@@ -196,78 +117,10 @@ export const Selectable = {
     const totalItems = 100
     const [currentPage, setCurrentPage] = useState(1)
     const [pageSize, setPageSize] = useState(10)
-    const [sortColumn, setSortColumn] = useState<{
-      key: string
-      order: string
-    }>({
-      key: '',
-      order: '',
-    })
-    const [selectedRows, setSelectedRows] = useState<RowData[]>()
 
     const startRange = (currentPage - 1) * pageSize
     const endRange = startRange + pageSize
-
-    let fullData = [...data]
-
-    if (sortColumn && sortColumn.key !== '') {
-      const { key, order } = sortColumn
-      const isDesc = order === 'desc'
-
-      fullData = fullData.sort((a, b) => {
-        if (typeof a[key] === 'string' && typeof b[key] === 'string') {
-          const newA = a[key]
-          const newB = b[key]
-
-          return isDesc ? newA.localeCompare(newB) : newB.localeCompare(newA)
-        }
-
-        const newA = a[key] as number
-        const newB = b[key] as number
-
-        return isDesc ? newA - newB : newB - newA
-      })
-    }
-
-    const dataByPage = fullData.slice(startRange, endRange) as RowData[]
-
-    const selectableRenderRow = (
-      rowData: RowData,
-      rowProps?: Record<string, any>,
-    ) => {
-      const handleOnRowSelected = ({ checked }: any) => {
-        setSelectedRows((current = [] as RowData[]) => {
-          if (checked) {
-            return [...current, rowData]
-          }
-
-          return current.filter((item) => item.id !== rowData.id)
-        })
-      }
-
-      return (
-        <TableRow {...rowProps}>
-          <TableCell>
-            <Checkbox
-              name={`checkbox-${rowData.id}`}
-              onCheckedChange={handleOnRowSelected}
-              checked={selectedRows?.some((item) => item.id === rowData.id)}
-            />
-          </TableCell>
-          <TableCell>{rowData.name}</TableCell>
-          <TableCell>{rowData.email}</TableCell>
-          <TableCell>{rowData.age}</TableCell>
-        </TableRow>
-      )
-    }
-
-    const onAllItemsSelected = (checked: boolean) => {
-      if (checked) {
-        setSelectedRows(dataByPage)
-      } else {
-        setSelectedRows([])
-      }
-    }
+    const dataByPage = data.slice(startRange, endRange) as RowData[]
 
     return (
       <div style={{ width: '56.25rem' }}>
@@ -275,8 +128,6 @@ export const Selectable = {
           {...args}
           columns={columns}
           data={dataByPage}
-          renderRow={selectableRenderRow}
-          onSortColumn={setSortColumn}
           onPageSizeChange={setPageSize}
           onPageChange={setCurrentPage}
           pagination={{
@@ -285,8 +136,6 @@ export const Selectable = {
             pageSize,
             showItemCount: true,
           }}
-          onAllItemsSelected={onAllItemsSelected}
-          selectedRows={selectedRows}
           selectable
         />
       </div>
@@ -311,10 +160,6 @@ type WideRowData = RowData & {
   role: string
   department: string
   status: string
-}
-
-type RenderRowContext = {
-  getCellProps?: (columnKey: string) => Record<string, any>
 }
 
 const wideData: WideRowData[] = Array(100)
@@ -360,51 +205,10 @@ export const ScrollableTable = {
     const totalItems = 100
     const [currentPage, setCurrentPage] = useState(1)
     const [pageSize, setPageSize] = useState(10)
-    const [sortColumn, setSortColumn] = useState<{
-      key: string
-      order: string
-    }>({
-      key: '',
-      order: '',
-    })
 
     const startRange = (currentPage - 1) * pageSize
     const endRange = startRange + pageSize
-
-    let fullData = [...wideData]
-
-    if (sortColumn && sortColumn.key !== '') {
-      const { key, order } = sortColumn
-      const isDesc = order === 'desc'
-
-      fullData = fullData.sort((a, b) => {
-        const aVal = (a as any)[key]
-        const bVal = (b as any)[key]
-
-        if (typeof aVal === 'string' && typeof bVal === 'string') {
-          return isDesc ? aVal.localeCompare(bVal) : bVal.localeCompare(aVal)
-        }
-
-        return isDesc
-          ? (aVal as number) - (bVal as number)
-          : (bVal as number) - (aVal as number)
-      })
-    }
-
-    const dataByPage = fullData.slice(startRange, endRange)
-
-    const renderRow = (rowData: WideRowData) => (
-      <TableRow>
-        <TableCell>{rowData.name}</TableCell>
-        <TableCell>{rowData.email}</TableCell>
-        <TableCell>{rowData.age}</TableCell>
-        <TableCell>{rowData.country}</TableCell>
-        <TableCell>{rowData.city}</TableCell>
-        <TableCell>{rowData.role}</TableCell>
-        <TableCell>{rowData.department}</TableCell>
-        <TableCell>{rowData.status}</TableCell>
-      </TableRow>
-    )
+    const dataByPage = wideData.slice(startRange, endRange)
 
     return (
       <div style={{ padding: '1.5rem', maxWidth: '800px' }}>
@@ -412,8 +216,6 @@ export const ScrollableTable = {
           {...args}
           columns={wideColumns}
           data={dataByPage}
-          renderRow={renderRow}
-          onSortColumn={setSortColumn}
           onPageSizeChange={setPageSize}
           onPageChange={setCurrentPage}
           pagination={{
@@ -428,57 +230,15 @@ export const ScrollableTable = {
   },
 }
 
-const makeStickyStoryRender =
-  () => (args: StoryObj<typeof TableStory>['args']) => {
+function makeStickyStoryRender() {
+  return function StickyStoryRender(args: StoryObj<typeof TableStory>['args']) {
     const totalItems = 100
     const [currentPage, setCurrentPage] = useState(1)
     const [pageSize, setPageSize] = useState(10)
-    const [sortColumn, setSortColumn] = useState<{
-      key: string
-      order: string
-    }>({ key: '', order: '' })
 
     const startRange = (currentPage - 1) * pageSize
     const endRange = startRange + pageSize
-
-    let fullData = [...wideData]
-
-    if (sortColumn && sortColumn.key !== '') {
-      const { key, order } = sortColumn
-      const isDesc = order === 'desc'
-
-      fullData = fullData.sort((a, b) => {
-        const aVal = (a as any)[key]
-        const bVal = (b as any)[key]
-
-        if (typeof aVal === 'string' && typeof bVal === 'string') {
-          return isDesc ? aVal.localeCompare(bVal) : bVal.localeCompare(aVal)
-        }
-
-        return isDesc
-          ? (aVal as number) - (bVal as number)
-          : (bVal as number) - (aVal as number)
-      })
-    }
-
-    const dataByPage = fullData.slice(startRange, endRange)
-
-    const renderRow = (rowData: WideRowData, context?: RenderRowContext) => (
-      <TableRow>
-        <TableCell {...context?.getCellProps?.('name')}>
-          {rowData.name}
-        </TableCell>
-        <TableCell {...context?.getCellProps?.('email')}>
-          {rowData.email}
-        </TableCell>
-        <TableCell>{rowData.age}</TableCell>
-        <TableCell>{rowData.country}</TableCell>
-        <TableCell>{rowData.city}</TableCell>
-        <TableCell>{rowData.role}</TableCell>
-        <TableCell>{rowData.department}</TableCell>
-        <TableCell>{rowData.status}</TableCell>
-      </TableRow>
-    )
+    const dataByPage = wideData.slice(startRange, endRange)
 
     return (
       <div style={{ padding: '1.5rem', maxWidth: '800px' }}>
@@ -486,8 +246,6 @@ const makeStickyStoryRender =
           {...args}
           columns={stickyWideColumns}
           data={dataByPage}
-          renderRow={renderRow}
-          onSortColumn={setSortColumn}
           onPageSizeChange={setPageSize}
           onPageChange={setCurrentPage}
           pagination={{
@@ -500,6 +258,7 @@ const makeStickyStoryRender =
       </div>
     )
   }
+}
 
 export const StickyColumns = {
   name: 'Sticky Columns',
@@ -582,35 +341,10 @@ export const CustomizableColumnWidths = {
     const totalItems = 100
     const [currentPage, setCurrentPage] = useState(1)
     const [pageSize, setPageSize] = useState(10)
-    const [sortColumn, setSortColumn] = useState<{
-      key: string
-      order: string
-    }>({ key: '', order: '' })
 
     const startRange = (currentPage - 1) * pageSize
     const endRange = startRange + pageSize
-
-    let fullData = [...wideData]
-
-    if (sortColumn && sortColumn.key !== '') {
-      const { key, order } = sortColumn
-      const isDesc = order === 'desc'
-
-      fullData = fullData.sort((a, b) => {
-        const aVal = (a as any)[key]
-        const bVal = (b as any)[key]
-
-        if (typeof aVal === 'string' && typeof bVal === 'string') {
-          return isDesc ? aVal.localeCompare(bVal) : bVal.localeCompare(aVal)
-        }
-
-        return isDesc
-          ? (aVal as number) - (bVal as number)
-          : (bVal as number) - (aVal as number)
-      })
-    }
-
-    const dataByPage = fullData.slice(startRange, endRange)
+    const dataByPage = wideData.slice(startRange, endRange)
 
     const columnsWithControls = [
       {
@@ -635,31 +369,165 @@ export const CustomizableColumnWidths = {
       { key: 'status', label: 'Status', sortable: true },
     ]
 
-    const renderRow = (rowData: WideRowData, context?: RenderRowContext) => (
-      <TableRow>
-        <TableCell {...context?.getCellProps?.('name')}>
-          {rowData.name}
-        </TableCell>
-        <TableCell {...context?.getCellProps?.('email')}>
-          {rowData.email}
-        </TableCell>
-        <TableCell {...context?.getCellProps?.('age')}>{rowData.age}</TableCell>
-        <TableCell>{rowData.country}</TableCell>
-        <TableCell>{rowData.city}</TableCell>
-        <TableCell>{rowData.role}</TableCell>
-        <TableCell>{rowData.department}</TableCell>
-        <TableCell>{rowData.status}</TableCell>
-      </TableRow>
-    )
-
     return (
       <div style={{ padding: '1.5rem', maxWidth: '900px' }}>
         <TableStory
           {...tableArgs}
           columns={columnsWithControls}
           data={dataByPage}
+          onPageSizeChange={setPageSize}
+          onPageChange={setCurrentPage}
+          pagination={{
+            totalItems,
+            currentPage,
+            pageSize,
+            showItemCount: true,
+          }}
+        />
+      </div>
+    )
+  },
+}
+
+export const ColumnCellOverrides = {
+  name: 'Column Cell Overrides',
+  args: {
+    height: '300px',
+    stickyHeader: true,
+  },
+  parameters: {
+    layout: 'fullscreen',
+    docs: {
+      description: {
+        story:
+          'Shows per-column custom cell rendering via columns[i].cell, without writing a full renderRow.',
+      },
+    },
+  },
+  render: (args: StoryObj<typeof TableStory>['args']) => {
+    const totalItems = 100
+    const [currentPage, setCurrentPage] = useState(1)
+    const [pageSize, setPageSize] = useState(10)
+
+    const startRange = (currentPage - 1) * pageSize
+    const endRange = startRange + pageSize
+    const dataByPage = wideData.slice(startRange, endRange)
+
+    const overrideColumns = [
+      {
+        key: 'name',
+        label: 'Name',
+        sortable: true,
+        width: '12rem',
+        sticky: true,
+      },
+      {
+        key: 'email',
+        label: 'Email',
+        sortable: true,
+        width: '18rem',
+        cell: (row: WideRowData) => row.email.toLowerCase(),
+      },
+      {
+        key: 'age',
+        label: 'Age',
+        sortable: true,
+        width: '8rem',
+        cell: (row: WideRowData) => `${row.age} yrs`,
+      },
+      {
+        key: 'status',
+        label: 'Status',
+        sortable: true,
+        cell: (row: WideRowData) =>
+          row.status === 'Active' ? 'Active' : 'Review',
+      },
+      { key: 'country', label: 'Country', sortable: true },
+      { key: 'city', label: 'City', sortable: true },
+      { key: 'role', label: 'Role', sortable: true },
+      { key: 'department', label: 'Department', sortable: true },
+    ]
+
+    return (
+      <div style={{ padding: '1.5rem', maxWidth: '900px' }}>
+        <TableStory
+          {...args}
+          columns={overrideColumns}
+          data={dataByPage}
+          onPageSizeChange={setPageSize}
+          onPageChange={setCurrentPage}
+          pagination={{
+            totalItems,
+            currentPage,
+            pageSize,
+            showItemCount: true,
+          }}
+        />
+      </div>
+    )
+  },
+}
+
+export const CustomRowRenderer = {
+  name: 'Custom Row Renderer',
+  args: {
+    height: '300px',
+    stickyHeader: true,
+  },
+  parameters: {
+    layout: 'fullscreen',
+    docs: {
+      description: {
+        story:
+          'Use renderRow when row structure must change dynamically (for example, review queues where some rows collapse details into a merged cell with colSpan and custom actions).',
+      },
+    },
+  },
+  render: (args: StoryObj<typeof TableStory>['args']) => {
+    const totalItems = 100
+    const [currentPage, setCurrentPage] = useState(1)
+    const [pageSize, setPageSize] = useState(10)
+
+    const startRange = (currentPage - 1) * pageSize
+    const endRange = startRange + pageSize
+    const dataByPage = wideData.slice(startRange, endRange)
+
+    const renderRow = (rowData: WideRowData) => {
+      const needsReview = rowData.status !== 'Active'
+
+      if (needsReview) {
+        return (
+          <TableRow>
+            <TableCell>{rowData.name}</TableCell>
+            <TableCell>{rowData.email}</TableCell>
+            <TableCell colSpan={6}>
+              Requires compliance review before activation
+            </TableCell>
+          </TableRow>
+        )
+      }
+
+      return (
+        <TableRow>
+          <TableCell>{rowData.name}</TableCell>
+          <TableCell>{rowData.email}</TableCell>
+          <TableCell>{`${rowData.age} years`}</TableCell>
+          <TableCell>{rowData.country}</TableCell>
+          <TableCell>{rowData.city}</TableCell>
+          <TableCell>{rowData.role}</TableCell>
+          <TableCell>{rowData.department}</TableCell>
+          <TableCell>View details</TableCell>
+        </TableRow>
+      )
+    }
+
+    return (
+      <div style={{ padding: '1.5rem', maxWidth: '900px' }}>
+        <TableStory
+          {...args}
+          columns={wideColumns}
+          data={dataByPage}
           renderRow={renderRow}
-          onSortColumn={setSortColumn}
           onPageSizeChange={setPageSize}
           onPageChange={setCurrentPage}
           pagination={{

--- a/src/components/DataDisplay/Table/Table.test.tsx
+++ b/src/components/DataDisplay/Table/Table.test.tsx
@@ -1,4 +1,4 @@
-import { render } from '@testing-library/react'
+import { fireEvent, render } from '@testing-library/react'
 import { axe } from 'jest-axe'
 
 import Table, { TableCell, TableRow } from '.'
@@ -51,5 +51,42 @@ describe('Table — accessibility', () => {
     )
 
     expect(await axe(container)).toHaveNoViolations()
+  })
+
+  it('renders with internal default renderer when renderRow is omitted', async () => {
+    const { container, getByText } = render(
+      <Table
+        columns={columns}
+        data={data}
+        onSortColumn={() => {}}
+        onPageSizeChange={() => {}}
+        onPageChange={() => {}}
+        pagination={{ totalItems: 2, currentPage: 1, pageSize: 10 }}
+      />,
+    )
+
+    expect(getByText('Jane Doe')).toBeInTheDocument()
+    expect(getByText('john@example.com')).toBeInTheDocument()
+    expect(await axe(container)).toHaveNoViolations()
+  })
+
+  it('sorts internally when onSortColumn is not provided', () => {
+    const { container, getAllByLabelText } = render(
+      <Table
+        columns={columns}
+        data={data}
+        onPageSizeChange={() => {}}
+        onPageChange={() => {}}
+        pagination={{ totalItems: 2, currentPage: 1, pageSize: 10 }}
+      />,
+    )
+
+    const descendingButtons = getAllByLabelText('Descending')
+    fireEvent.click(descendingButtons[0])
+
+    const tableContent = container.textContent || ''
+    expect(tableContent.indexOf('John Doe')).toBeLessThan(
+      tableContent.indexOf('Jane Doe'),
+    )
   })
 })

--- a/src/components/DataDisplay/Table/TableDemo.tsx
+++ b/src/components/DataDisplay/Table/TableDemo.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react'
-import { Table, TableRow, TableCell, Checkbox } from '../..'
+import { Table, TableRow, TableCell } from '../..'
 import DemoWrapper from '../../UI/DemoWrapper'
 
 export const columns = [
@@ -69,115 +69,45 @@ const stickyData: StickyRowData[] = Array(100)
     status: ['Active', 'Inactive', 'Pending'][i % 3],
   }))
 
-type RenderRowContext = {
-  className?: string
-  getCellProps?: (columnKey: string) => Record<string, any>
-}
-
 const TableDemo = () => {
   const totalItems = 100
   const [currentPage, setCurrentPage] = useState(1)
   const [pageSize, setPageSize] = useState(10)
-  const [sortColumn, setSortColumn] = useState<{ key: string; order: string }>({
-    key: '',
-    order: '',
-  })
-  const [selectedRows, setSelectedRows] = useState<RowData[]>()
 
   const startRange = (currentPage - 1) * pageSize
   const endRange = startRange + pageSize
 
-  let fullData = [...data]
-
-  if (sortColumn && sortColumn.key !== '') {
-    const { key, order } = sortColumn
-    const isDesc = order === 'desc'
-
-    fullData = fullData.sort((a, b) => {
-      if (typeof a[key] === 'string' && typeof b[key] === 'string') {
-        const newA = a[key]
-        const newB = b[key]
-
-        return isDesc ? newA.localeCompare(newB) : newB.localeCompare(newA)
-      }
-
-      const newA = a[key] as number
-      const newB = b[key] as number
-
-      return isDesc ? newA - newB : newB - newA
-    })
-  }
-
-  const dataByPage = fullData.slice(startRange, endRange) as RowData[]
+  const dataByPage = data.slice(startRange, endRange) as RowData[]
   const stickyDataByPage = stickyData.slice(startRange, endRange)
 
-  const renderRow = (rowData: RowData) => (
-    <TableRow>
-      <TableCell>{rowData.name}</TableCell>
-      <TableCell>{rowData.email}</TableCell>
-      <TableCell>{rowData.age}</TableCell>
-    </TableRow>
-  )
+  const customRenderRow = (rowData: StickyRowData) => {
+    const needsReview = rowData.status !== 'Active'
 
-  const selectableRenderRow = (
-    rowData: RowData,
-    rowProps?: Record<string, any>,
-  ) => {
-    const handleOnRowSelected = ({ checked }: any) => {
-      setSelectedRows((current = [] as RowData[]) => {
-        if (checked) {
-          return [...current, rowData]
-        }
-
-        return current.filter((item) => item.id !== rowData.id)
-      })
+    if (needsReview) {
+      return (
+        <TableRow>
+          <TableCell>{rowData.name}</TableCell>
+          <TableCell>{rowData.email}</TableCell>
+          <TableCell colSpan={6}>
+            Requires compliance review before activation
+          </TableCell>
+        </TableRow>
+      )
     }
 
     return (
-      <TableRow
-        {...rowProps}
-        aria-selected={selectedRows?.some((item) => item.id === rowData.id)}
-      >
-        <TableCell>
-          <Checkbox
-            name={`checkbox-${rowData.id}`}
-            aria-label={`Select row ${rowData.name}`}
-            onCheckedChange={handleOnRowSelected}
-            checked={selectedRows?.some((item) => item.id === rowData.id)}
-          />
-        </TableCell>
+      <TableRow>
         <TableCell>{rowData.name}</TableCell>
         <TableCell>{rowData.email}</TableCell>
-        <TableCell>{rowData.age}</TableCell>
+        <TableCell>{`${rowData.age} years`}</TableCell>
+        <TableCell>{rowData.country}</TableCell>
+        <TableCell>{rowData.city}</TableCell>
+        <TableCell>{rowData.role}</TableCell>
+        <TableCell>{rowData.department}</TableCell>
+        <TableCell>View details</TableCell>
       </TableRow>
     )
   }
-
-  const onAllItemsSelected = (checked: boolean) => {
-    if (checked) {
-      setSelectedRows(dataByPage)
-    } else {
-      setSelectedRows([])
-    }
-  }
-
-  const stickyRenderRow = (
-    rowData: StickyRowData,
-    context?: RenderRowContext,
-  ) => (
-    <TableRow>
-      <TableCell {...context?.getCellProps?.('name')}>{rowData.name}</TableCell>
-      <TableCell {...context?.getCellProps?.('email')}>
-        {rowData.email}
-      </TableCell>
-      <TableCell>{rowData.age}</TableCell>
-      <TableCell>{rowData.country}</TableCell>
-      <TableCell>{rowData.city}</TableCell>
-      <TableCell>{rowData.role}</TableCell>
-      <TableCell>{rowData.department}</TableCell>
-      <TableCell>{rowData.status}</TableCell>
-    </TableRow>
-  )
 
   return (
     <DemoWrapper title='Table'>
@@ -188,8 +118,6 @@ const TableDemo = () => {
           <Table
             columns={columns}
             data={dataByPage}
-            renderRow={renderRow}
-            onSortColumn={setSortColumn}
             onPageSizeChange={setPageSize}
             onPageChange={setCurrentPage}
             pagination={{
@@ -204,8 +132,6 @@ const TableDemo = () => {
         <div style={{ width: '100%', maxWidth: '56.25rem' }}>
           <Table
             columns={columns}
-            renderRow={renderRow}
-            onSortColumn={setSortColumn}
             onPageSizeChange={setPageSize}
             onPageChange={setCurrentPage}
             pagination={{
@@ -223,8 +149,6 @@ const TableDemo = () => {
           <Table
             columns={columns}
             data={dataByPage}
-            renderRow={selectableRenderRow}
-            onSortColumn={setSortColumn}
             onPageSizeChange={setPageSize}
             onPageChange={setCurrentPage}
             pagination={{
@@ -233,8 +157,6 @@ const TableDemo = () => {
               pageSize,
               showItemCount: true,
             }}
-            onAllItemsSelected={onAllItemsSelected}
-            selectedRows={selectedRows}
             selectable
           />
         </div>
@@ -245,8 +167,6 @@ const TableDemo = () => {
           <Table
             columns={stickyColumns}
             data={stickyDataByPage}
-            renderRow={stickyRenderRow}
-            onSortColumn={setSortColumn}
             onPageSizeChange={setPageSize}
             onPageChange={setCurrentPage}
             pagination={{
@@ -265,8 +185,6 @@ const TableDemo = () => {
           <Table
             columns={stickyColumns}
             data={stickyDataByPage}
-            renderRow={stickyRenderRow}
-            onSortColumn={setSortColumn}
             onPageSizeChange={setPageSize}
             onPageChange={setCurrentPage}
             pagination={{
@@ -277,6 +195,24 @@ const TableDemo = () => {
             }}
             stickyHeader
             height='18.75rem'
+          />
+        </div>
+        <div style={{ width: '100%', maxWidth: '56.25rem' }}>
+          <p style={{ marginBottom: '0.5rem', fontWeight: 600 }}>
+            Custom Row Renderer
+          </p>
+          <Table
+            columns={stickyColumns}
+            data={stickyDataByPage}
+            renderRow={customRenderRow}
+            onPageSizeChange={setPageSize}
+            onPageChange={setCurrentPage}
+            pagination={{
+              totalItems,
+              currentPage,
+              pageSize,
+              showItemCount: true,
+            }}
           />
         </div>
       </div>

--- a/src/components/DataDisplay/Table/defaultRenderRow.tsx
+++ b/src/components/DataDisplay/Table/defaultRenderRow.tsx
@@ -1,0 +1,52 @@
+import React from 'react'
+import { Table as ChakraTable } from '@chakra-ui/react'
+import Checkbox from '../../Forms/Controls/Checkbox'
+import { TableColumn, TableRenderRowContext } from './types'
+
+type CreateDefaultRowRendererParams = {
+  columns: TableColumn[]
+  selectable?: boolean
+  isRowSelected: (rowData: any) => boolean
+  onRowSelected: (rowData: any, checked: boolean) => void
+}
+
+export const createDefaultRowRenderer = ({
+  columns,
+  selectable,
+  isRowSelected,
+  onRowSelected,
+}: CreateDefaultRowRendererParams) => {
+  const defaultRowRenderer = (
+    rowData: any,
+    rowContext?: TableRenderRowContext,
+  ) => {
+    const { id, name } = rowData
+
+    return (
+      <ChakraTable.Row className={rowContext?.className}>
+        {selectable ? (
+          <ChakraTable.Cell>
+            <Checkbox
+              name={`checkbox-${id}`}
+              aria-label={`Select row ${name || id}`}
+              checked={isRowSelected(rowData)}
+              onCheckedChange={({ checked }: any) => {
+                onRowSelected(rowData, checked)
+              }}
+            />
+          </ChakraTable.Cell>
+        ) : null}
+        {columns.map((column) => (
+          <ChakraTable.Cell
+            key={column.key}
+            {...rowContext?.getCellProps(column.key)}
+          >
+            {column.cell ? column.cell(rowData) : rowData?.[column.key]}
+          </ChakraTable.Cell>
+        ))}
+      </ChakraTable.Row>
+    )
+  }
+
+  return defaultRowRenderer
+}

--- a/src/components/DataDisplay/Table/index.tsx
+++ b/src/components/DataDisplay/Table/index.tsx
@@ -23,6 +23,20 @@ import IconButton from '../../Forms/Actions/IconButton'
 import Checkbox from '../../Forms/Controls/Checkbox'
 import { getThemedColor } from '../../../lib/theme'
 import { useLabels } from '../../../lib/i18n/useLabels'
+import {
+  calculateStickyOffsets,
+  createColumnsByKey,
+  getCellProps as getCellPropsHelper,
+  getColumnWidthProps as getColumnWidthPropsHelper,
+  getLastStickyColumnKey,
+  getSortedDisplayData,
+  getStickyColumnKeys,
+  getStickyProps as getStickyPropsHelper,
+  isRowSelected as isRowSelectedHelper,
+  keepSelectedRowsInCurrentData,
+  toggleSelectedRow,
+} from './utils'
+import { createDefaultRowRenderer } from './defaultRenderRow'
 
 const Table = ({
   columns,
@@ -38,6 +52,7 @@ const Table = ({
   onPageSizeChange,
   onPageChange,
   onAllItemsSelected,
+  onRowSelected,
   loading,
   height,
   labels,
@@ -49,6 +64,7 @@ const Table = ({
   })
   const headerCellRefs = useRef<Record<string, HTMLTableCellElement | null>>({})
   const [stickyOffsets, setStickyOffsets] = useState<Record<string, number>>({})
+  const [internalSelectedRows, setInternalSelectedRows] = useState<any[]>([])
 
   const {
     totalItems = data.length,
@@ -57,6 +73,12 @@ const Table = ({
     showItemCount,
     showItemCountText,
   } = pagination || {}
+  const hasExternalSortHandler = Boolean(onSortColumn)
+
+  const displayData = useMemo(
+    () => getSortedDisplayData(data, sortColumn, hasExternalSortHandler),
+    [data, hasExternalSortHandler, sortColumn],
+  )
 
   const onSort = (columnKey: string, order: string) => {
     setSortColumn({ key: columnKey, order })
@@ -66,33 +88,22 @@ const Table = ({
     }
   }
 
-  const allChecked = selectedRows?.length === data?.length
-  const indeterminate = selectedRows && selectedRows.length > 0 && !allChecked
-  const columnsByKey = useMemo(
-    () =>
-      columns.reduce<Record<string, TableColumn>>((acc, column) => {
-        acc[column.key] = column
-        return acc
-      }, {}),
+  const effectiveSelectedRows = selectedRows ?? internalSelectedRows
+  const allChecked =
+    displayData.length > 0 &&
+    effectiveSelectedRows.length === displayData.length
+  const indeterminate =
+    effectiveSelectedRows.length > 0 &&
+    effectiveSelectedRows.length < displayData.length
+  const columnsByKey = useMemo(() => createColumnsByKey(columns), [columns])
+  const stickyColumnKeys = useMemo(
+    () => getStickyColumnKeys(columns),
     [columns],
   )
-  const stickyColumnKeys = columns
-    .filter((column) => column.sticky)
-    .map((column) => column.key)
-  const lastStickyColumnKey =
-    stickyColumnKeys.length > 0
-      ? stickyColumnKeys[stickyColumnKeys.length - 1]
-      : undefined
+  const lastStickyColumnKey = getLastStickyColumnKey(stickyColumnKeys)
 
   const calculateStickyPositions = useCallback(() => {
-    const nextOffsets: Record<string, number> = {}
-    let offset = 0
-    columns
-      .filter((column) => column.sticky)
-      .forEach((column) => {
-        nextOffsets[column.key] = offset
-        offset += headerCellRefs.current[column.key]?.offsetWidth || 0
-      })
+    const nextOffsets = calculateStickyOffsets(columns, headerCellRefs.current)
     setStickyOffsets(nextOffsets)
   }, [columns])
 
@@ -112,42 +123,53 @@ const Table = ({
     }
   }, [calculateStickyPositions])
 
-  const getColumnWidthProps = (columnKey: string) => {
-    const width = columnsByKey[columnKey]?.width
-
-    if (!width) {
-      return {}
+  useEffect(() => {
+    if (selectedRows !== undefined) {
+      return
     }
 
-    return {
-      width,
-      minWidth: width,
+    setInternalSelectedRows((current) =>
+      keepSelectedRowsInCurrentData(current, data),
+    )
+  }, [data, selectedRows])
+
+  const getColumnWidthProps = (columnKey: string) =>
+    getColumnWidthPropsHelper(columnsByKey, columnKey)
+
+  const getStickyProps = (column: TableColumn) =>
+    getStickyPropsHelper(stickyOffsets, column.key, lastStickyColumnKey)
+
+  const getCellProps = (columnKey: string) =>
+    getCellPropsHelper(
+      columnsByKey,
+      stickyOffsets,
+      columnKey,
+      lastStickyColumnKey,
+    )
+
+  const isRowSelected = (rowData: any) =>
+    isRowSelectedHelper(effectiveSelectedRows, rowData)
+
+  const handleRowSelected = (rowData: any, checked: boolean) => {
+    if (selectedRows === undefined) {
+      setInternalSelectedRows((current) =>
+        toggleSelectedRow(current, rowData, checked),
+      )
+    }
+
+    if (onRowSelected) {
+      onRowSelected(rowData, checked)
     }
   }
 
-  const getStickyProps = (column: TableColumn) => {
-    const offset = stickyOffsets[column.key]
-    if (offset === undefined) return {}
-    return {
-      'data-sticky': 'start',
-      'data-sticky-last':
-        column.key === lastStickyColumnKey ? 'true' : undefined,
-      left: `${offset}px`,
-    }
-  }
+  const defaultRenderRow = createDefaultRowRenderer({
+    columns,
+    selectable,
+    isRowSelected,
+    onRowSelected: handleRowSelected,
+  })
 
-  const getCellProps = (columnKey: string) => {
-    const widthProps = getColumnWidthProps(columnKey)
-    const offset = stickyOffsets[columnKey]
-    if (offset === undefined) return widthProps
-    return {
-      ...widthProps,
-      'data-sticky': 'start',
-      'data-sticky-last':
-        columnKey === lastStickyColumnKey ? 'true' : undefined,
-      left: `${offset}px`,
-    }
-  }
+  const rowRenderer = renderRow || defaultRenderRow
 
   return (
     <div>
@@ -168,6 +190,10 @@ const Table = ({
                     checked={allChecked}
                     indeterminate={indeterminate}
                     onCheckedChange={({ checked }: any) => {
+                      if (selectedRows === undefined) {
+                        setInternalSelectedRows(checked ? displayData : [])
+                      }
+
                       if (onAllItemsSelected) {
                         onAllItemsSelected(checked)
                       }
@@ -227,14 +253,10 @@ const Table = ({
             </ChakraTable.Row>
           </ChakraTable.Header>
           <ChakraTable.Body css={tableBodyStyles}>
-            {data.map((item: any) => (
+            {displayData.map((item: any) => (
               <React.Fragment key={item.id}>
-                {renderRow(item, {
-                  className: selectedRows?.some(
-                    (row: any) => row.id === item.id,
-                  )
-                    ? 'selected'
-                    : undefined,
+                {rowRenderer(item, {
+                  className: isRowSelected(item) ? 'selected' : undefined,
                   getCellProps,
                 })}
               </React.Fragment>

--- a/src/components/DataDisplay/Table/types.ts
+++ b/src/components/DataDisplay/Table/types.ts
@@ -8,6 +8,8 @@ export type TableColumn = {
   label: string
   sortable?: boolean
   width?: string
+  /** Optional custom renderer for this column cell. */
+  cell?: (row: any) => ReactNode
   /** When true, this column sticks to the left during horizontal scroll. */
   sticky?: boolean
 }
@@ -20,7 +22,7 @@ export type TableRenderRowContext = {
 export type TableProps = {
   columns: TableColumn[]
   data?: any
-  renderRow: (row: any, context?: TableRenderRowContext) => ReactNode
+  renderRow?: (row: any, context?: TableRenderRowContext) => ReactNode
   striped?: boolean
   stickyHeader?: boolean
   selectable?: boolean
@@ -37,6 +39,7 @@ export type TableProps = {
   onPageSizeChange?: (pageSize: number) => void
   onPageChange?: (page: number) => void
   onAllItemsSelected?: (checked: boolean) => void
+  onRowSelected?: (row: any, checked: boolean) => void
   loading?: boolean
   /** When set, the table scrolls vertically within this height and horizontally when it overflows its container (e.g. '400px', '60vh'). */
   height?: string

--- a/src/components/DataDisplay/Table/utils.ts
+++ b/src/components/DataDisplay/Table/utils.ts
@@ -1,0 +1,152 @@
+import { TableColumn } from './types'
+
+type SortColumnState = {
+  key: string
+  order: string
+}
+
+export const createColumnsByKey = (columns: TableColumn[]) =>
+  columns.reduce<Record<string, TableColumn>>((acc, column) => {
+    acc[column.key] = column
+    return acc
+  }, {})
+
+export const getStickyColumnKeys = (columns: TableColumn[]) =>
+  columns.filter((column) => column.sticky).map((column) => column.key)
+
+export const getLastStickyColumnKey = (stickyColumnKeys: string[]) =>
+  stickyColumnKeys.length > 0
+    ? stickyColumnKeys[stickyColumnKeys.length - 1]
+    : undefined
+
+export const calculateStickyOffsets = (
+  columns: TableColumn[],
+  headerCellRefs: Record<string, HTMLTableCellElement | null>,
+) => {
+  const nextOffsets: Record<string, number> = {}
+  let offset = 0
+
+  columns
+    .filter((column) => column.sticky)
+    .forEach((column) => {
+      nextOffsets[column.key] = offset
+      offset += headerCellRefs[column.key]?.offsetWidth || 0
+    })
+
+  return nextOffsets
+}
+
+export const getColumnWidthProps = (
+  columnsByKey: Record<string, TableColumn>,
+  columnKey: string,
+) => {
+  const width = columnsByKey[columnKey]?.width
+
+  if (!width) {
+    return {}
+  }
+
+  return {
+    width,
+    minWidth: width,
+  }
+}
+
+export const getStickyProps = (
+  stickyOffsets: Record<string, number>,
+  columnKey: string,
+  lastStickyColumnKey?: string,
+) => {
+  const offset = stickyOffsets[columnKey]
+
+  if (offset === undefined) {
+    return {}
+  }
+
+  return {
+    'data-sticky': 'start',
+    'data-sticky-last': columnKey === lastStickyColumnKey ? 'true' : undefined,
+    left: `${offset}px`,
+  }
+}
+
+export const getCellProps = (
+  columnsByKey: Record<string, TableColumn>,
+  stickyOffsets: Record<string, number>,
+  columnKey: string,
+  lastStickyColumnKey?: string,
+) => {
+  const widthProps = getColumnWidthProps(columnsByKey, columnKey)
+  const stickyProps = getStickyProps(
+    stickyOffsets,
+    columnKey,
+    lastStickyColumnKey,
+  )
+
+  return {
+    ...widthProps,
+    ...stickyProps,
+  }
+}
+
+export const keepSelectedRowsInCurrentData = (selected: any[], data: any[]) =>
+  selected.filter((row) => data.some((item) => item.id === row.id))
+
+export const toggleSelectedRow = (
+  current: any[],
+  rowData: any,
+  checked: boolean,
+) => {
+  if (checked) {
+    if (current.some((row) => row.id === rowData.id)) {
+      return current
+    }
+
+    return [...current, rowData]
+  }
+
+  return current.filter((row) => row.id !== rowData.id)
+}
+
+export const isRowSelected = (selectedRows: any[], rowData: any) =>
+  selectedRows.some((row) => row.id === rowData.id)
+
+const compareBySortOrder = (valueA: any, valueB: any, isAscending: boolean) => {
+  if (valueA == null && valueB == null) return 0
+  if (valueA == null) return 1
+  if (valueB == null) return -1
+
+  if (typeof valueA === 'string' && typeof valueB === 'string') {
+    return isAscending
+      ? valueA.localeCompare(valueB)
+      : valueB.localeCompare(valueA)
+  }
+
+  if (typeof valueA === 'number' && typeof valueB === 'number') {
+    return isAscending ? valueA - valueB : valueB - valueA
+  }
+
+  const stringA = String(valueA)
+  const stringB = String(valueB)
+
+  return isAscending
+    ? stringA.localeCompare(stringB)
+    : stringB.localeCompare(stringA)
+}
+
+export const getSortedDisplayData = (
+  data: any[],
+  sortColumn: SortColumnState,
+  hasExternalSortHandler: boolean,
+) => {
+  if (hasExternalSortHandler || !sortColumn.key) {
+    return data
+  }
+
+  const { key, order } = sortColumn
+  const isAscending = order === 'asc'
+
+  return [...data].sort((a: any, b: any) =>
+    compareBySortOrder(a?.[key], b?.[key], isAscending),
+  )
+}


### PR DESCRIPTION
## What
Refactors the Table component to support a simpler default API while preserving advanced customization, and adds auto sorting behavior that switches between internal and external modes based on whether `onSortColumn` is provided.

## Why
Table usage had become too verbose for common cases and required repeated parent-side sorting/rendering boilerplate in demos and stories. This change makes the default path easier (`columns + data`) while keeping extension points for complex rows and external sorting/data flows.

## Changes

- Added auto sorting mode:
  - If `onSortColumn` is provided, Table behaves as externally sorted (notifies parent only).
  - If `onSortColumn` is omitted, Table sorts internally using current sort state.
- Extracted sorting logic into utility helpers to reduce complexity in `Table/index.tsx`.
- Extracted default row rendering into `defaultRenderRow.tsx` to simplify the main Table component.
- Kept `renderRow` optional and preserved `TableRenderRowContext` for advanced row control.
- Added/updated column-level customization via `cell`, `width`, and sticky behavior in the default renderer path.
- Preserved selectable behavior with the default renderer (including select-all and row selection handling).
- Simplified Storybook stories to rely on auto/internal sorting by default (removed repetitive parent sort plumbing).
- Kept an explicit advanced `CustomRowRenderer` story with a concrete use case (dynamic row structure with `colSpan`).
- Simplified `TableDemo` to showcase cleaner default usage.
- Updated README with:
  - Simplified usage examples
  - Auto sorting behavior explanation
  - Explicit external override example using `onSortColumn`
- Added regression coverage for internal sorting when `onSortColumn` is not provided.

## Before / After

- Before:
  - Basic implementations commonly required parent-managed sort state and manual sorted data.
- After:
  - Basic implementations can omit `onSortColumn` and get internal sorting automatically.
  - External sorting remains available by passing `onSortColumn` and controlling sorted data in the parent.
