### PR TITLE
[Toast] - manual close + custom width

### DIFF
--- a/src/components/Status/Toast/README.md
+++ b/src/components/Status/Toast/README.md
@@ -47,6 +47,7 @@ type ToastLabels = {
 }
 
 type ToastProps = {
+  id?: string // Optional ID for the toast, useful for programmatically closing it
   label: string
   caption?: React.ReactNode
   type: 'success' | 'warning' | 'error' | 'info' | 'loading'
@@ -66,6 +67,7 @@ type ToastProps = {
   closable?: boolean
   closableLabel?: string
   onClose?: () => void
+  maxWidth?: string
 }
 
 type ToastComponentProps = {
@@ -272,4 +274,25 @@ showToast({
   closable: true,
   onClose: () => console.log('Closed'),
 })
+```
+
+### Custom Width
+
+```tsx
+showToast({
+  label: 'Validating Polygons...',
+  type: 'info',
+  placement: 'bottom',
+  maxWidth: '15.625rem', // 250px
+})
+```
+
+### Manual Close
+
+```tsx
+closeToast()
+```
+
+```tsx
+closeToast(toastId)
 ```

--- a/src/components/Status/Toast/Toast.stories.tsx
+++ b/src/components/Status/Toast/Toast.stories.tsx
@@ -5,7 +5,7 @@ import React from 'react'
 import type { Meta, StoryObj } from '@storybook/react'
 import Button from '../../Forms/Actions/Button'
 import Toast from '.'
-import { showToast } from './utils'
+import { closeToast, showToast } from './utils'
 import { CheckIcon } from '../../icons'
 
 const meta = {
@@ -370,6 +370,52 @@ export const OnClose: Story = {
             closable: true,
             // eslint-disable-next-line no-alert
             onClose: () => alert('Closed'),
+          })
+        }
+      />
+    ),
+  ],
+}
+
+export const ManualClose: Story = {
+  decorators: [
+    () => (
+      <div style={{ display: 'flex', gap: '0.5rem', flexWrap: 'wrap' }}>
+        <Button
+          label='Show'
+          variant='primary'
+          onClick={() =>
+            showToast({
+              id: 'show-toast-id',
+              label: 'Label',
+              caption: 'Caption',
+              type: 'loading',
+              placement: 'bottom',
+            })
+          }
+        />
+        <Button
+          label='Close'
+          variant='secondary'
+          onClick={() => closeToast('show-toast-id')}
+        />
+      </div>
+    ),
+  ],
+}
+
+export const CustomWidth: Story = {
+  decorators: [
+    () => (
+      <Button
+        label='Show'
+        variant='primary'
+        onClick={() =>
+          showToast({
+            label: 'Validating Polygons...',
+            type: 'info',
+            placement: 'bottom',
+            maxWidth: '15.625rem', // 250px
           })
         }
       />

--- a/src/components/Status/Toast/ToastDemo.tsx
+++ b/src/components/Status/Toast/ToastDemo.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable no-console */
-import { Button, showToast } from '../..'
+import { Button, showToast, closeToast } from '../..'
 import DemoWrapper from '../../UI/DemoWrapper'
 
 const ToastDemo = () => (
@@ -111,6 +111,26 @@ const ToastDemo = () => (
           })
         }
       />
+      <div style={{ display: 'flex', gap: '0.5rem', flexWrap: 'wrap' }}>
+        <Button
+          label='Show'
+          variant='primary'
+          onClick={() =>
+            showToast({
+              id: 'show-toast-id',
+              label: 'Validating Polygons...',
+              type: 'loading',
+              placement: 'bottom',
+              maxWidth: '15.625rem', // 250px
+            })
+          }
+        />
+        <Button
+          label='Close'
+          variant='secondary'
+          onClick={() => closeToast('show-toast-id')}
+        />
+      </div>
     </div>
   </DemoWrapper>
 )

--- a/src/components/Status/Toast/index.tsx
+++ b/src/components/Status/Toast/index.tsx
@@ -34,8 +34,15 @@ const Toast: React.FC<ToastComponentProps> = ({ labels }) => {
     <Portal key={toaster}>
       <ChakraToaster toaster={toasters[toaster]} insetInline={{ mdDown: '4' }}>
         {(toast) => (
-          <ChakraToast.Root css={toastContainerStyles} width={{ md: 'sm' }}>
-            <Stack flexDirection='row' className='ds-toast-icon-container'>
+          <ChakraToast.Root
+            css={toastContainerStyles(toast.meta?.maxWidth)}
+            width={{ md: 'sm' }}
+          >
+            <Stack
+              flexDirection='row'
+              className='ds-toast-icon-container'
+              alignItems={toast.description ? 'flex-start' : 'center'}
+            >
               {toast.type === 'info' ? (
                 toast.meta?.icon ? (
                   toast.meta.icon

--- a/src/components/Status/Toast/styled.ts
+++ b/src/components/Status/Toast/styled.ts
@@ -8,7 +8,7 @@ import {
   getThemedSpacing,
 } from '../../../lib/theme'
 
-export const toastContainerStyles = css`
+export const toastContainerStyles = (maxWidth?: string) => css`
   justify-content: space-between;
   align-items: center;
   gap: ${getThemedSpacing(200)};
@@ -18,6 +18,7 @@ export const toastContainerStyles = css`
   border: ${getThemedBorderWidth(100)} solid ${getThemedColor('neutral', 300)};
   box-shadow: 0rem 0.25rem 0.375rem -0.25rem #0000001a;
   box-shadow: 0rem 0.625rem 0.9375rem -0.1875rem #0000001a;
+  width: ${maxWidth ? `${maxWidth} !important` : '100%'};
 
   .ds-toast-icon-container svg {
     width: ${getThemedSpacing(500)};

--- a/src/components/Status/Toast/types.ts
+++ b/src/components/Status/Toast/types.ts
@@ -3,6 +3,7 @@ import type { ToastLabels } from '../../../lib/i18n/types'
 export type { ToastLabels }
 
 export type ToastProps = {
+  id?: string // Optional ID for the toast, useful for programmatically closing it
   label: string
   caption?: React.ReactNode
   type: 'success' | 'warning' | 'error' | 'info' | 'loading'
@@ -22,6 +23,7 @@ export type ToastProps = {
   closable?: boolean
   closableLabel?: string
   onClose?: () => void
+  maxWidth?: string
 }
 
 export type ToastComponentProps = {

--- a/src/components/Status/Toast/utils.ts
+++ b/src/components/Status/Toast/utils.ts
@@ -57,7 +57,14 @@ export const showToast = (props: ToastProps) => {
       icon: props.icon,
       closableLabel: props.closableLabel,
       onClose: props.onClose,
+      maxWidth: props.maxWidth,
     },
     ...props,
+  })
+}
+
+export const closeToast = (id?: string) => {
+  Object.values(toasters).forEach((toaster) => {
+    toaster.dismiss(id)
   })
 }

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -264,6 +264,6 @@ export { default as StepProgressIndicator } from './Status/StepProgressIndicator
 export type { StepProgressIndicatorProps } from './Status/StepProgressIndicator/types'
 export { default as Toast } from './Status/Toast'
 export type { ToastComponentProps, ToastProps } from './Status/Toast/types'
-export { showToast } from './Status/Toast/utils'
+export { showToast, closeToast } from './Status/Toast/utils'
 
 // -- Status -- //


### PR DESCRIPTION
## What
Adds manual Toast dismissal support and optional custom Toast width, with docs and Storybook examples.

## Why
Consumers needed a way to close Toasts programmatically (for example, stopping a loading Toast after an async flow) and to control Toast width in specific UI contexts.

## Changes
- Added a new closeToast utility that can:
  - Dismiss a specific Toast by id
  - Dismiss all Toasts when called without id
- Extended Toast API with:
  - id (optional) to target a Toast for manual close
  - maxWidth (optional) to allow custom width
- Updated showToast to forward maxWidth into Toast metadata.
- Updated Toast rendering/styling to:
  - Apply optional maxWidth
  - Improve icon vertical alignment when caption is present
- Exported closeToast from the component barrel so it is available to consumers.
- Added Storybook coverage for:
  - ManualClose flow (Show + Close buttons)
  - CustomWidth usage
- Updated Toast demo to include manual close and custom width usage.
- Updated README with API additions and usage examples for custom width and manual close.

## Before / After
- Before: Toasts were only triggered via showToast and width was effectively fixed.
- After: Toasts can be manually dismissed with closeToast and can optionally use a custom maxWidth.