### PR TITLE
[Multi Action Button] - max width

### DIFF
--- a/src/components/Forms/Actions/MultiActionButton/styled.ts
+++ b/src/components/Forms/Actions/MultiActionButton/styled.ts
@@ -10,7 +10,8 @@ import {
 import { MultiActionButtonProps } from './types'
 
 export const menuContentStyles = css`
-  width: 12.5rem;
+  width: 100%;
+  max-width: 12.5rem;
   border: ${getThemedBorderWidth(100)} solid ${getThemedColor('neutral', 600)};
   border-radius: ${getThemedRadius(300)};
   padding: ${getThemedSpacing(200)};


### PR DESCRIPTION
## What

This PR updates MultiActionButton menu content sizing so it can be responsive while still capping its maximum width.

## Why

Using a fixed width made the menu less flexible in narrower layouts. This change keeps the existing visual size target while allowing the menu container to adapt to available space.

## Changes

- Updated menu content styles in styled.ts
- Replaced fixed width with responsive width plus max-width:
  - Before: width: 12.5rem;
  - After:
    width: 100%;
    max-width: 12.5rem;
- No component API changes
- No file renames or deletions

## Notes

- Scope is limited to styling only
- Expected behavior: menu can shrink with container constraints but will not exceed 12.5rem