### PR TITLE
[DS-311] - no optional label

### DIFF
--- a/src/components/Forms/Inputs/Combobox/Combobox.stories.tsx
+++ b/src/components/Forms/Inputs/Combobox/Combobox.stories.tsx
@@ -74,6 +74,16 @@ export const Optional: Story = {
   },
 }
 
+export const OptionalNoOptionalLabel: Story = {
+  args: {
+    label: 'Label',
+    caption: 'Caption',
+    placeholder: 'Search...',
+    initialItems: ITEMS,
+    showOptionalLabel: false,
+  },
+}
+
 export const Small: Story = {
   args: {
     label: 'Label',

--- a/src/components/Forms/Inputs/Combobox/Combobox.test.tsx
+++ b/src/components/Forms/Inputs/Combobox/Combobox.test.tsx
@@ -23,4 +23,27 @@ describe('Combobox — accessibility', () => {
 
     expect(await axe(container)).toHaveNoViolations()
   })
+
+  it('shows optional label by default for non-required fields', () => {
+    const { container } = render(
+      <Combobox
+        label='Country'
+        initialItems={[{ label: 'Colombia', value: 'co' }]}
+      />,
+    )
+
+    expect(container.textContent).toContain('(Optional)')
+  })
+
+  it('hides optional label when showOptionalLabel is false', () => {
+    const { container } = render(
+      <Combobox
+        label='Country'
+        showOptionalLabel={false}
+        initialItems={[{ label: 'Colombia', value: 'co' }]}
+      />,
+    )
+
+    expect(container.textContent).not.toContain('(Optional)')
+  })
 })

--- a/src/components/Forms/Inputs/Combobox/ComboboxDemo.tsx
+++ b/src/components/Forms/Inputs/Combobox/ComboboxDemo.tsx
@@ -26,6 +26,13 @@ const ComboboxDemo = () => (
     />
     <Combobox
       initialItems={items}
+      label='Label'
+      caption='Caption'
+      placeholder='placeholder'
+      showOptionalLabel={false}
+    />
+    <Combobox
+      initialItems={items}
       label='Multiple'
       caption='Caption'
       placeholder='placeholder'

--- a/src/components/Forms/Inputs/Combobox/README.md
+++ b/src/components/Forms/Inputs/Combobox/README.md
@@ -45,6 +45,7 @@ type ComboboxProps = {
   errorMessage?: string
   size?: 'small' | 'default'
   disabled?: boolean
+  showOptionalLabel?: boolean
   placeholder?: string
   labels?: Partial<ComboboxLabels>
   noMarginBottom?: boolean

--- a/src/components/Forms/Inputs/Combobox/index.tsx
+++ b/src/components/Forms/Inputs/Combobox/index.tsx
@@ -28,6 +28,7 @@ const Combobox = ({
   errorMessage,
   size,
   disabled,
+  showOptionalLabel = true,
   placeholder,
   labels,
   noMarginBottom,
@@ -72,7 +73,9 @@ const Combobox = ({
           >
             <Field.RequiredIndicator aria-label={l.requiredSymbolLabel} />
             {label}
-            {!required ? <span>{l.optionalSuffix}</span> : ''}
+            {!required && showOptionalLabel ? (
+              <span>{l.optionalSuffix}</span>
+            ) : null}
           </Field.Label>
         ) : null}
         {caption ? (

--- a/src/components/Forms/Inputs/Combobox/types.ts
+++ b/src/components/Forms/Inputs/Combobox/types.ts
@@ -10,6 +10,7 @@ export type ComboboxProps = {
   errorMessage?: string
   size?: 'small' | 'default'
   disabled?: boolean
+  showOptionalLabel?: boolean
   placeholder?: string
   labels?: Partial<ComboboxLabels>
   noMarginBottom?: boolean

--- a/src/components/Forms/Inputs/TextInput/README.md
+++ b/src/components/Forms/Inputs/TextInput/README.md
@@ -41,6 +41,7 @@ type TextInputProps = Omit<
   required?: boolean
   disabled?: boolean
   size?: 'small' | 'default'
+  showOptionalLabel?: boolean
   noMarginBottom?: boolean
   defaultValue?: string
   onChange?: (e: React.ChangeEvent<HTMLInputElement>) => void

--- a/src/components/Forms/Inputs/TextInput/TextInput.stories.tsx
+++ b/src/components/Forms/Inputs/TextInput/TextInput.stories.tsx
@@ -81,6 +81,14 @@ export const OptionalInput: Story = {
   },
 }
 
+export const OptionalInputNoOptionalLabel: Story = {
+  args: {
+    label: 'Label',
+    caption: 'Caption',
+    showOptionalLabel: false,
+  },
+}
+
 export const SmallInput: Story = {
   args: {
     label: 'Label',

--- a/src/components/Forms/Inputs/TextInput/TextInput.test.tsx
+++ b/src/components/Forms/Inputs/TextInput/TextInput.test.tsx
@@ -34,4 +34,24 @@ describe('TextInput — accessibility', () => {
 
     expect(await axe(container)).toHaveNoViolations()
   })
+
+  it('shows optional label by default for non-required fields', () => {
+    const { container } = render(
+      <TextInput label='Email address' aria-label='Email address' />,
+    )
+
+    expect(container.textContent).toContain('(Optional)')
+  })
+
+  it('hides optional label when showOptionalLabel is false', () => {
+    const { container } = render(
+      <TextInput
+        label='Email address'
+        aria-label='Email address'
+        showOptionalLabel={false}
+      />,
+    )
+
+    expect(container.textContent).not.toContain('(Optional)')
+  })
 })

--- a/src/components/Forms/Inputs/TextInput/TextInputDemo.tsx
+++ b/src/components/Forms/Inputs/TextInput/TextInputDemo.tsx
@@ -21,6 +21,12 @@ const TextInputDemo = () => (
         label='Label'
         caption='Caption'
         placeholder='placeholder'
+        showOptionalLabel={false}
+      />
+      <TextInput
+        label='Label'
+        caption='Caption'
+        placeholder='placeholder'
         errorMessage='Error Message'
         required
       />

--- a/src/components/Forms/Inputs/TextInput/index.tsx
+++ b/src/components/Forms/Inputs/TextInput/index.tsx
@@ -23,6 +23,7 @@ const TextInput = ({
   required,
   disabled,
   size = 'default',
+  showOptionalLabel = true,
   noMarginBottom = false,
   defaultValue = '',
   onChange,
@@ -59,7 +60,9 @@ const TextInput = ({
           >
             <Field.RequiredIndicator aria-label={l.requiredSymbolLabel} />
             {label}
-            {!required ? <span>{l.optionalSuffix}</span> : ''}
+            {!required && showOptionalLabel ? (
+              <span>{l.optionalSuffix}</span>
+            ) : null}
           </Field.Label>
         ) : null}
         {caption ? (

--- a/src/components/Forms/Inputs/TextInput/types.ts
+++ b/src/components/Forms/Inputs/TextInput/types.ts
@@ -14,6 +14,7 @@ export type TextInputProps = Omit<
   required?: boolean
   disabled?: boolean
   size?: 'small' | 'default'
+  showOptionalLabel?: boolean
   noMarginBottom?: boolean
   defaultValue?: string
   onChange?: (e: React.ChangeEvent<HTMLInputElement>) => void

--- a/src/components/Forms/Inputs/Textarea/README.md
+++ b/src/components/Forms/Inputs/Textarea/README.md
@@ -63,7 +63,7 @@ type TextareaProps = Omit<
   size?: 'small' | 'default'
   showOptionalLabel?: boolean
   defaultValue?: string
-  onChange?: (e: React.ChangeEvent<HTMLInputElement>) => void
+  onChange?: (e: React.ChangeEvent<HTMLTextAreaElement>) => void
   minLength?: number
   maxLength?: number
   /** Override internal UI labels for internationalization support. */

--- a/src/components/Forms/Inputs/Textarea/README.md
+++ b/src/components/Forms/Inputs/Textarea/README.md
@@ -61,6 +61,7 @@ type TextareaProps = Omit<
   required?: boolean
   disabled?: boolean
   size?: 'small' | 'default'
+  showOptionalLabel?: boolean
   defaultValue?: string
   onChange?: (e: React.ChangeEvent<HTMLInputElement>) => void
   minLength?: number

--- a/src/components/Forms/Inputs/Textarea/Textarea.stories.tsx
+++ b/src/components/Forms/Inputs/Textarea/Textarea.stories.tsx
@@ -78,6 +78,14 @@ export const OptionalTextarea: Story = {
   },
 }
 
+export const OptionalTextareaNoOptionalLabel: Story = {
+  args: {
+    label: 'Label',
+    caption: 'Caption',
+    showOptionalLabel: false,
+  },
+}
+
 export const SmallTextarea: Story = {
   args: {
     label: 'Label',

--- a/src/components/Forms/Inputs/Textarea/Textarea.test.tsx
+++ b/src/components/Forms/Inputs/Textarea/Textarea.test.tsx
@@ -36,4 +36,24 @@ describe('Textarea — accessibility', () => {
 
     expect(await axe(container)).toHaveNoViolations()
   })
+
+  it('shows optional label by default for non-required fields', () => {
+    const { container } = render(
+      <Textarea label='Description' aria-label='Description' />,
+    )
+
+    expect(container.textContent).toContain('(Optional)')
+  })
+
+  it('hides optional label when showOptionalLabel is false', () => {
+    const { container } = render(
+      <Textarea
+        label='Description'
+        aria-label='Description'
+        showOptionalLabel={false}
+      />,
+    )
+
+    expect(container.textContent).not.toContain('(Optional)')
+  })
 })

--- a/src/components/Forms/Inputs/Textarea/TextareaDemo.tsx
+++ b/src/components/Forms/Inputs/Textarea/TextareaDemo.tsx
@@ -23,6 +23,15 @@ const TextareaDemo = () => (
         label='Label'
         caption='Caption'
         placeholder='Placeholder'
+        defaultValue='Default Value'
+        minLength={5}
+        maxLength={200}
+        showOptionalLabel={false}
+      />
+      <Textarea
+        label='Label'
+        caption='Caption'
+        placeholder='Placeholder'
         errorMessage='Error Message'
         required
       />

--- a/src/components/Forms/Inputs/Textarea/index.tsx
+++ b/src/components/Forms/Inputs/Textarea/index.tsx
@@ -23,6 +23,7 @@ const Textarea = ({
   required,
   disabled,
   size = 'default',
+  showOptionalLabel = true,
   defaultValue = '',
   onChange,
   minLength,
@@ -110,7 +111,9 @@ const Textarea = ({
           >
             <Field.RequiredIndicator aria-label={l.requiredSymbolLabel} />
             {label}
-            {!required ? <span>{l.optionalSuffix}</span> : ''}
+            {!required && showOptionalLabel ? (
+              <span>{l.optionalSuffix}</span>
+            ) : null}
           </Field.Label>
         ) : null}
 

--- a/src/components/Forms/Inputs/Textarea/types.ts
+++ b/src/components/Forms/Inputs/Textarea/types.ts
@@ -16,7 +16,7 @@ export type TextareaProps = Omit<
   size?: 'small' | 'default'
   showOptionalLabel?: boolean
   defaultValue?: string
-  onChange?: (e: React.ChangeEvent<HTMLInputElement>) => void
+  onChange?: (e: React.ChangeEvent<HTMLTextAreaElement>) => void
   minLength?: number
   maxLength?: number
   /** Override internal UI labels for internationalization support. */

--- a/src/components/Forms/Inputs/Textarea/types.ts
+++ b/src/components/Forms/Inputs/Textarea/types.ts
@@ -14,6 +14,7 @@ export type TextareaProps = Omit<
   required?: boolean
   disabled?: boolean
   size?: 'small' | 'default'
+  showOptionalLabel?: boolean
   defaultValue?: string
   onChange?: (e: React.ChangeEvent<HTMLInputElement>) => void
   minLength?: number


### PR DESCRIPTION
## What

This PR adds a configurable optional label behavior for input components by introducing a new prop, showOptionalLabel, in TextInput, Textarea, and Combobox, while preserving the current default behavior.

## Why

Figma designs do not always include the Optional text next to field labels.  
We need a way to hide that label in specific use cases without breaking existing implementations that rely on the current default display.

## Changes

- Added showOptionalLabel to the public props for:
  - TextInput
  - Textarea
  - Combobox
- Kept backward-compatible default behavior:
  - showOptionalLabel defaults to true
  - Optional text still renders by default on non-required fields
- Updated label rendering logic in all three components:
  - Before: Optional text always rendered when required was false
  - After: Optional text renders only when required is false and showOptionalLabel is true
- Renamed usage from showOptionalSuffix to showOptionalLabel across branch changes for API consistency.
- Added/updated tests in all three components to verify:
  - Optional label is shown by default
  - Optional label is hidden when showOptionalLabel is false
- Updated stories, demos, and READMEs to document and demonstrate showOptionalLabel behavior.

## Validation

- Ran targeted tests for TextInput, Textarea, and Combobox.
- Result: all related test suites pass.