### PR TITLE
menu link fix

### DIFF
--- a/src/components/Forms/Actions/Menu/Menu.test.tsx
+++ b/src/components/Forms/Actions/Menu/Menu.test.tsx
@@ -1,4 +1,4 @@
-import { render } from '@testing-library/react'
+import { render, screen } from '@testing-library/react'
 import { axe } from 'jest-axe'
 
 import Menu from '.'
@@ -45,5 +45,43 @@ describe('Menu — accessibility', () => {
       />,
     )
     expect(await axe(container)).toHaveNoViolations()
+  })
+})
+
+describe('Menu — link items', () => {
+  it('renders an anchor with the correct href for a linked item', () => {
+    render(
+      <Menu
+        label='Links'
+        items={[
+          {
+            label: 'Open docs',
+            value: 'docs',
+            link: 'https://example.com/docs',
+          },
+        ]}
+      />,
+    )
+    const anchor = screen.getByRole('link', { name: /open docs/i })
+    expect(anchor).toHaveAttribute('href', 'https://example.com/docs')
+  })
+
+  it('marks a disabled linked item as aria-disabled and keeps the href', () => {
+    render(
+      <Menu
+        label='Links'
+        items={[
+          {
+            label: 'Disabled link',
+            value: 'disabled',
+            link: 'https://example.com',
+            disabled: true,
+          },
+        ]}
+      />,
+    )
+    const anchor = screen.getByRole('link', { name: /disabled link/i })
+    expect(anchor).toHaveAttribute('href', 'https://example.com')
+    expect(anchor).toHaveAttribute('aria-disabled', 'true')
   })
 })

--- a/src/components/Forms/Actions/Menu/MenuDemo.tsx
+++ b/src/components/Forms/Actions/Menu/MenuDemo.tsx
@@ -18,7 +18,8 @@ const MenuDemo = () => (
         label='Open Menu'
         items={[
           {
-            label: 'Label',
+            label: 'Label with link',
+            link: 'https://www.google.com',
             value: 'label-1-1',
           },
           {

--- a/src/components/Forms/Actions/Menu/MenuItem.tsx
+++ b/src/components/Forms/Actions/Menu/MenuItem.tsx
@@ -50,7 +50,15 @@ const renderMenuItemBody = (
   if (item.children) return item.children
   if (item.link)
     return (
-      <a href={item.link} rel='noopener noreferrer'>
+      <a
+        href={item.disabled ? undefined : item.link}
+        aria-disabled={item.disabled || undefined}
+        tabIndex={item.disabled ? -1 : undefined}
+        onClick={(e) => {
+          if (item.disabled) e.preventDefault()
+        }}
+        style={{ textDecoration: 'none', color: 'inherit' }}
+      >
         <MenuItemContent item={item} isChecked={isChecked} labels={labels} />
       </a>
     )

--- a/src/components/Forms/Actions/Menu/MenuItem.tsx
+++ b/src/components/Forms/Actions/Menu/MenuItem.tsx
@@ -12,6 +12,51 @@ import {
   menuItemLabelContentStyles,
 } from './menuItemStyled'
 
+const MenuItemContent = ({
+  item,
+  isChecked,
+  labels,
+}: {
+  item: MenuItemProps
+  isChecked: boolean
+  labels: MenuLabels
+}) => (
+  <>
+    {item.startIcon}
+    <div css={menuItemLabelAndCaptionStyles(!!item.startIcon, !!item.endIcon)}>
+      <div css={menuItemLabelContentStyles(isChecked)}>
+        <p className='ds-menu-item-label'>{item.label}</p>
+        {item.command ? (
+          <ChakraMenu.ItemCommand
+            aria-label={`${labels.shortcutPrefix} ${item.command}`}
+          >
+            {item.command}
+          </ChakraMenu.ItemCommand>
+        ) : null}
+      </div>
+      {item.caption ? (
+        <p className='ds-menu-item-caption'>{item.caption}</p>
+      ) : null}
+    </div>
+    {isChecked ? <CheckIcon /> : item.endIcon}
+  </>
+)
+
+const renderMenuItemBody = (
+  item: MenuItemProps,
+  isChecked: boolean,
+  labels: MenuLabels,
+) => {
+  if (item.children) return item.children
+  if (item.link)
+    return (
+      <a href={item.link} target='_blank' rel='noopener noreferrer'>
+        <MenuItemContent item={item} isChecked={isChecked} labels={labels} />
+      </a>
+    )
+  return <MenuItemContent item={item} isChecked={isChecked} labels={labels} />
+}
+
 const MenuItem = ({
   item,
   isChecked = false,
@@ -27,32 +72,9 @@ const MenuItem = ({
     disabled={item.disabled}
     role='menuitem'
     aria-label={item.label}
+    asChild={!!item.link}
   >
-    {item.children ? (
-      item.children
-    ) : (
-      <>
-        {item.startIcon}
-        <div
-          css={menuItemLabelAndCaptionStyles(!!item.startIcon, !!item.endIcon)}
-        >
-          <div css={menuItemLabelContentStyles(isChecked)}>
-            <p className='ds-menu-item-label'>{item.label}</p>
-            {item.command ? (
-              <ChakraMenu.ItemCommand
-                aria-label={`${labels.shortcutPrefix} ${item.command}`}
-              >
-                {item.command}
-              </ChakraMenu.ItemCommand>
-            ) : null}
-          </div>
-          {item.caption ? (
-            <p className='ds-menu-item-caption'>{item.caption}</p>
-          ) : null}
-        </div>
-        {isChecked ? <CheckIcon /> : item.endIcon}
-      </>
-    )}
+    {renderMenuItemBody(item, isChecked, labels)}
   </ChakraMenu.Item>
 )
 

--- a/src/components/Forms/Actions/Menu/MenuItem.tsx
+++ b/src/components/Forms/Actions/Menu/MenuItem.tsx
@@ -51,7 +51,7 @@ const renderMenuItemBody = (
   if (item.link)
     return (
       <a
-        href={item.disabled ? undefined : item.link}
+        href={item.link}
         aria-disabled={item.disabled || undefined}
         tabIndex={item.disabled ? -1 : undefined}
         onClick={(e) => {
@@ -80,7 +80,7 @@ const MenuItem = ({
     disabled={item.disabled}
     role='menuitem'
     aria-label={item.label}
-    asChild={!!item.link}
+    asChild={!!item.link && !item.children}
   >
     {renderMenuItemBody(item, isChecked, labels)}
   </ChakraMenu.Item>

--- a/src/components/Forms/Actions/Menu/MenuItem.tsx
+++ b/src/components/Forms/Actions/Menu/MenuItem.tsx
@@ -50,7 +50,7 @@ const renderMenuItemBody = (
   if (item.children) return item.children
   if (item.link)
     return (
-      <a href={item.link} target='_blank' rel='noopener noreferrer'>
+      <a href={item.link} rel='noopener noreferrer'>
         <MenuItemContent item={item} isChecked={isChecked} labels={labels} />
       </a>
     )


### PR DESCRIPTION

<img width="268" height="269" alt="Screenshot 2026-07-07 at 1 35 39 p m" src="https://github.com/user-attachments/assets/edfcf45c-da61-4b93-80f9-bcdfa265fc8a" />


## What is the new behavior?
clicking on the link is not redirecting because the link prop is ignored in the component

```
 const items = [
        {
            label: 'Dashboard',
            value: 'dashboard',
            link: '/dashboard',
        },
        {
            label: 'Settings',
            value: 'settings',
            link: `/dashboard/settings/edit/${session.data?.user.name}`,
        },

    ];


            <Menu
                label={session.data?.user.name ?? 'User menu'}
                items={items}
                hideArrow >

```

## Does this introduce a breaking change?

- [ ] Yes
- [x] No
