### PR TITLE
[DS-330] Fix Panel layout with CSS flexbox instead of JS height calculations

### DIFF
--- a/src/components/Containers/Panel/Templates/AnalysisPanelFixed.stories.tsx
+++ b/src/components/Containers/Panel/Templates/AnalysisPanelFixed.stories.tsx
@@ -217,7 +217,6 @@ export const Fixed: Story = {
                       style={{
                         display: 'flex',
                         padding: '0.5rem',
-                        marginBottom: '3.125rem',
                       }}
                     >
                       <Tag

--- a/src/components/Containers/Panel/Templates/FilterPanel.stories.tsx
+++ b/src/components/Containers/Panel/Templates/FilterPanel.stories.tsx
@@ -120,13 +120,22 @@ export const FilterPanel: Story = {
           </Box>
         }
         content={
-          <div style={{ maxHeight: '31.25rem' }}>
-            <div>
+          <div
+            style={{
+              maxHeight: '31.25rem',
+              display: 'flex',
+              flexDirection: 'column',
+              gap: '0.9375rem',
+            }}
+          >
+            <div style={{ flex: 1 }}>
               <Box
                 style={{
                   border: `0.0625rem solid ${getThemedColor('neutral', 300)}`,
                   padding: '0.9375rem',
-                  margin: '0.9375rem',
+                  marginRight: '0.9375rem',
+                  marginLeft: '0.9375rem',
+                  marginTop: '0.9375rem',
                   borderRadius: '0.3125rem',
                 }}
               >
@@ -215,12 +224,14 @@ export const FilterPanel: Story = {
                 </div>
               </Box>
             </div>
-            <div>
+            <div style={{ flex: 1 }}>
               <Box
                 style={{
                   border: `0.0625rem solid ${getThemedColor('neutral', 300)}`,
                   padding: '0.9375rem',
-                  margin: '0.9375rem',
+                  marginRight: '0.9375rem',
+                  marginBottom: '0.9375rem',
+                  marginLeft: '0.9375rem',
                   borderRadius: '0.3125rem',
                 }}
               >

--- a/src/components/Containers/Panel/index.tsx
+++ b/src/components/Containers/Panel/index.tsx
@@ -1,7 +1,7 @@
 /** @jsxImportSource @emotion/react */
 /* eslint-disable react/no-unknown-property */
 
-import { useEffect, useId, useRef, useState } from 'react'
+import { useId } from 'react'
 import {
   panelContainerStyles,
   panelContentContainerStyles,
@@ -20,19 +20,6 @@ const Panel = ({
   width,
 }: PanelProps) => {
   const headerId = useId()
-  const [headerHeight, setHeaderHeight] = useState<number | undefined>(
-    undefined,
-  )
-  const [footerHeight, setFooterHeight] = useState<number | undefined>(
-    undefined,
-  )
-  const headerRef = useRef<HTMLDivElement>(null)
-  const footerRef = useRef<HTMLDivElement>(null)
-
-  useEffect(() => {
-    setHeaderHeight(headerRef?.current?.getBoundingClientRect()?.height)
-    setFooterHeight(footerRef?.current?.getBoundingClientRect()?.height)
-  }, [header, footer])
 
   const panel = (
     <div
@@ -46,18 +33,12 @@ const Panel = ({
       ]}
     >
       {header ? (
-        <div id={headerId} css={panelHeaderContainerStyles} ref={headerRef}>
+        <div id={headerId} css={panelHeaderContainerStyles}>
           {header}
         </div>
       ) : null}
-      <div css={panelContentContainerStyles(headerHeight, footerHeight)}>
-        {content}
-      </div>
-      {footer ? (
-        <div css={panelFooterContainerStyles} ref={footerRef}>
-          {footer}
-        </div>
-      ) : null}
+      <div css={panelContentContainerStyles}>{content}</div>
+      {footer ? <div css={panelFooterContainerStyles}>{footer}</div> : null}
     </div>
   )
 

--- a/src/components/Containers/Panel/styled.ts
+++ b/src/components/Containers/Panel/styled.ts
@@ -8,12 +8,13 @@ import {
 import { PanelProps } from './types'
 
 export const panelContainerStyles = (width?: PanelProps['width']) => css`
+  display: flex;
+  flex-direction: column;
   height: 100%;
   width: ${width || '20rem'};
   background-color: ${getThemedColor('neutral', 100)};
   box-shadow: 0 0.0625rem 0.125rem -0.0625rem #0000001a;
   box-shadow: 0 0.0625rem 0.1875rem 0 #0000001a;
-  position: relative;
 `
 
 export const panelFixedContainerStyles = css`
@@ -27,25 +28,16 @@ export const panelFloatingContainerStyles = css`
 `
 
 export const panelHeaderContainerStyles = css`
+  flex-shrink: 0;
   min-height: ${getThemedSpacing(1200)};
   width: 100%;
   border-bottom: ${getThemedBorderWidth(100)} solid
     ${getThemedColor('neutral', 300)};
 `
 
-const getContentHeight = (headerHeight?: number, footerHeight?: number) => {
-  if (headerHeight && footerHeight)
-    return `calc(100% - ${(headerHeight + footerHeight) / 16}rem)`
-  if (headerHeight) return `calc(100% - ${headerHeight / 16}rem)`
-  if (footerHeight) return `calc(100% - ${footerHeight / 16}rem)`
-  return '100%'
-}
-
-export const panelContentContainerStyles = (
-  headerHeight?: number,
-  footerHeight?: number,
-) => css`
-  height: ${getContentHeight(headerHeight, footerHeight)};
+export const panelContentContainerStyles = css`
+  flex: 1;
+  min-height: 0;
   width: 100%;
   overflow-y: auto;
 
@@ -55,14 +47,12 @@ export const panelContentContainerStyles = (
 `
 
 export const panelFooterContainerStyles = css`
+  flex-shrink: 0;
   min-height: ${getThemedSpacing(1600)};
   width: 100%;
   display: flex;
   align-items: center;
   justify-content: flex-start;
-  position: absolute;
-  bottom: 0;
-  left: 0;
   border-top: ${getThemedBorderWidth(100)} solid
     ${getThemedColor('neutral', 300)};
 `

--- a/src/components/Forms/Controls/Switch/types.ts
+++ b/src/components/Forms/Controls/Switch/types.ts
@@ -1,5 +1,5 @@
-import type { SwitchLabels } from '../../../../lib/i18n/types'
 import { Switch as ChakraSwitch } from '@chakra-ui/react'
+import type { SwitchLabels } from '../../../../lib/i18n/types'
 
 export type { SwitchLabels }
 

--- a/src/components/Forms/Inputs/RichTextEditor/RichTextEditor.test.tsx
+++ b/src/components/Forms/Inputs/RichTextEditor/RichTextEditor.test.tsx
@@ -1,6 +1,8 @@
 import { render } from '@testing-library/react'
 import { axe } from 'jest-axe'
 
+import RichTextEditor from '.'
+
 jest.mock('@tiptap/starter-kit', () => ({
   __esModule: true,
   default: {
@@ -59,8 +61,6 @@ jest.mock('@tiptap/react', () => ({
   EditorContent: () => null,
   useEditor: () => null,
 }))
-
-import RichTextEditor from '.'
 
 jest.mock('@chakra-ui/react', () =>
   jest.requireActual('../../../testUtils').createChakraMock(),


### PR DESCRIPTION
What
Replaces the Panel component’s JS-driven height calculations with a CSS flexbox layout so header, scrollable content, and footer size correctly without measurement logic.

Why
The Panel previously measured header and footer heights in JavaScript and used calc() to size the content area, while the footer was absolutely positioned. That approach was brittle (one-time measurement, px-to-rem assumptions) and fought the layout model. A pure CSS flex layout handles dynamic header/footer heights and internal scrolling more reliably.

Changes
Panel layout (index.tsx, styled.ts)

Removed useState, useRef, and useEffect used to measure header/footer heights
Switched panel container to display: flex; flex-direction: column
Content area uses flex: 1, min-height: 0, and overflow-y: auto for proper scrolling
Footer moved from absolute positioning back into normal document flow with flex-shrink: 0
Removed unused getContentHeight helper and position: relative on the container
Before:

// JS measurement + calc-based height
const [headerHeight, setHeaderHeight] = useState<number | undefined>()
useEffect(() => {
  setHeaderHeight(headerRef?.current?.getBoundingClientRect()?.height)
}, [header, footer])
<div css={panelContentContainerStyles(headerHeight, footerHeight)}>
After:

// Pure CSS flex layout
<div css={panelContentContainerStyles}>{content}</div>
/* styled.ts */
display: flex;
flex-direction: column;
/* content */
flex: 1;
min-height: 0;
overflow-y: auto;
/* footer — no longer absolute */
flex-shrink: 0;
Story updates

AnalysisPanelFixed.stories.tsx — removed marginBottom workaround that compensated for the old absolute footer
FilterPanel.stories.tsx — adjusted content layout/margins to work with the new flex-based panel
Misc

Switch/types.ts — import order fix
RichTextEditor.test.tsx — moved component import above jest.mock calls