### PR TITLE
[DS-328] Add negative variant and disabled state fixes

### DIFF
--- a/src/components/Forms/Actions/Button/Button.stories.tsx
+++ b/src/components/Forms/Actions/Button/Button.stories.tsx
@@ -2,7 +2,6 @@
 import React from 'react'
 
 import type { Meta, StoryObj } from '@storybook/react'
-import { fn } from '@storybook/test'
 import Button from '.'
 import { CheckIcon } from '../../../icons'
 
@@ -15,18 +14,17 @@ const meta = {
     docs: {
       description: {
         component:
-          "Primary action button. Use `variant='primary'` for the main CTA, `variant='secondary'` for less prominent actions, `variant='borderless'` for inline text actions, and `variant='outline'` for bordered secondary actions. Prefer `IconButton` when no label is needed.",
+          "Primary action button. Use `variant='primary'` for the main CTA, `variant='secondary'` for less prominent actions, `variant='borderless'` for inline text actions, `variant='outline'` for bordered secondary actions, and `variant='negative'` for destructive actions. Prefer `IconButton` when no label is needed.",
       },
     },
   },
   tags: ['autodocs'],
-  args: { onClick: fn() },
   argTypes: {
     label: { description: 'Button text', control: 'text' },
     variant: {
       description: 'Visual style of the button',
       control: { type: 'select' },
-      options: ['primary', 'secondary', 'borderless', 'outline'],
+      options: ['primary', 'secondary', 'borderless', 'outline', 'negative'],
     },
     size: {
       description: "Size variant — use 'small' in compact layouts",
@@ -90,6 +88,13 @@ export const Outline: Story = {
   args: {
     label: 'Outline',
     variant: 'outline',
+  },
+}
+
+export const Negative: Story = {
+  args: {
+    label: 'Negative',
+    variant: 'negative',
   },
 }
 

--- a/src/components/Forms/Actions/Button/Button.test.tsx
+++ b/src/components/Forms/Actions/Button/Button.test.tsx
@@ -40,6 +40,11 @@ describe('Button — accessibility', () => {
     expect(await axe(container)).toHaveNoViolations()
   })
 
+  it('renders negative variant and has no violations', async () => {
+    const { container } = render(<Button variant='negative'>Delete</Button>)
+    expect(await axe(container)).toHaveNoViolations()
+  })
+
   it('renders outline variant and has no violations', async () => {
     const { container } = render(
       <Button variant='outline'>View details</Button>,

--- a/src/components/Forms/Actions/Button/ButtonDemo.tsx
+++ b/src/components/Forms/Actions/Button/ButtonDemo.tsx
@@ -64,6 +64,17 @@ const ButtonDemo = () => (
           flexWrap: 'wrap',
         }}
       >
+        <Button label='Button Label' variant='negative' />
+        <Button label='Button Label' variant='negative' size='small' />
+      </div>
+      <div
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          gap: '0.625rem',
+          flexWrap: 'wrap',
+        }}
+      >
         <SSOButtons.Google />
         <SSOButtons.Facebook />
         <SSOButtons.X />

--- a/src/components/Forms/Actions/Button/README.md
+++ b/src/components/Forms/Actions/Button/README.md
@@ -30,7 +30,7 @@ type ButtonProps = Omit<
 > & {
   label?: string
   loading?: boolean
-  variant?: 'primary' | 'secondary' | 'borderless' | 'outline'
+  variant?: 'primary' | 'secondary' | 'borderless' | 'outline' | 'negative'
   size?: 'default' | 'small'
   disabled?: boolean
   leftIcon?: React.ReactNode

--- a/src/components/Forms/Actions/Button/index.tsx
+++ b/src/components/Forms/Actions/Button/index.tsx
@@ -9,6 +9,7 @@ import {
   secondaryButtonStyles,
   borderlessButtonStyles,
   outlineButtonStyles,
+  negativeButtonStyles,
 } from './styled'
 import { useLabels } from '../../../../lib/i18n/useLabels'
 
@@ -36,6 +37,8 @@ const Button = forwardRef<HTMLButtonElement, ButtonProps>(
       variantButtonStyles = borderlessButtonStyles
     } else if (variant === 'outline') {
       variantButtonStyles = outlineButtonStyles
+    } else if (variant === 'negative') {
+      variantButtonStyles = negativeButtonStyles
     }
 
     const getAriaLabel = () => {
@@ -53,7 +56,7 @@ const Button = forwardRef<HTMLButtonElement, ButtonProps>(
     return (
       <ChakraButton
         aria-label={getAriaLabel()}
-        css={[baseButtonStyles(size), variantButtonStyles(disabled)]}
+        css={[baseButtonStyles(size), variantButtonStyles]}
         disabled={disabled || loading}
         aria-disabled={disabled || loading}
         ref={ref}

--- a/src/components/Forms/Actions/Button/styled.ts
+++ b/src/components/Forms/Actions/Button/styled.ts
@@ -213,7 +213,7 @@ export const negativeButtonStyles = css`
 
   &:active {
     outline: none;
-    background-color: ${getThemedColor('error', 400)} !important;
+    background-color: ${getThemedColor('error', 300)} !important;
     box-shadow: 0 0.125rem 0.25rem -0.125rem #0000001a;
     box-shadow: 0 0.25rem 0.375rem -0.0625rem #0000001a;
   }

--- a/src/components/Forms/Actions/Button/styled.ts
+++ b/src/components/Forms/Actions/Button/styled.ts
@@ -43,148 +43,191 @@ export const baseButtonStyles = (size: ButtonProps['size']) => css`
   }
 `
 
-export const primaryButtonStyles = (disabled?: boolean) => css`
-  ${disabled
-    ? `
+export const primaryButtonStyles = css`
+  background-color: ${getThemedColor('primary', 500)};
+  border: ${getThemedBorderWidth(100)} solid ${getThemedColor('primary', 600)};
+  color: ${getThemedColor('accessible', 'text-on-primary-mids') ||
+  getThemedColor('primary', 900)};
+  box-shadow: 0 0.0625rem 0.125rem 0 #0000000d;
+
+  &:hover {
+    background-color: ${getThemedColor('primary', 500)};
+    box-shadow: 0 0.125rem 0.25rem -0.125rem #0000001a;
+    box-shadow: 0 0.25rem 0.375rem -0.0625rem #0000001a;
+  }
+
+  &:active {
+    outline: none;
+    background-color: ${getThemedColor('primary', 600)} !important;
+    border: ${getThemedBorderWidth(100)} solid ${getThemedColor('primary', 700)} !important;
+    box-shadow: 0 0.125rem 0.25rem -0.125rem #0000001a;
+    box-shadow: 0 0.25rem 0.375rem -0.0625rem #0000001a;
+  }
+
+  &:focus-visible {
+    outline-color: ${getThemedColor('primary', 700)};
+    background-color: ${getThemedColor('primary', 500)};
+  }
+
+  &:disabled,
+  &[data-disabled] {
     background-color: ${getThemedColor('neutral', 300)};
     border: ${getThemedBorderWidth(100)} solid ${getThemedColor('neutral', 400)};
     color: ${getThemedColor('neutral', 500)};
-    cursor: not-allowed !important;
+    cursor: not-allowed;
+    opacity: 1;
 
     &:hover {
-      background-color: ${getThemedColor('neutral', 300)} !important;
+      background-color: ${getThemedColor('neutral', 300)};
     }
-  `
-    : `
-    background-color: ${getThemedColor('primary', 500)};
-    border: ${getThemedBorderWidth(100)} solid ${getThemedColor('primary', 600)};
-    color: ${getThemedColor('accessible', 'text-on-primary-mids') || getThemedColor('primary', 900)};
-    box-shadow: 0 0.0625rem 0.125rem 0 #0000000D;
-
-    &:hover {
-      background-color: ${getThemedColor('primary', 500)};
-      box-shadow: 0 0.125rem 0.25rem -0.125rem #0000001A;
-      box-shadow: 0 0.25rem 0.375rem -0.0625rem #0000001A;
-    }
-
-    &:active {
-      outline: none;
-      background-color: ${getThemedColor('primary', 600)} !important;
-      border: ${getThemedBorderWidth(100)} solid ${getThemedColor('primary', 700)} !important;
-      box-shadow: 0 0.125rem 0.25rem -0.125rem #0000001A;
-      box-shadow: 0 0.25rem 0.375rem -0.0625rem #0000001A;
-    }
-
-    &:focus-visible {
-      outline-color: ${getThemedColor('primary', 700)};
-      background-color: ${getThemedColor('primary', 500)};
-    }
-  `}
+  }
 `
 
-export const secondaryButtonStyles = (disabled?: boolean) => css`
-  ${disabled
-    ? `
-    background-color: ${getThemedColor('neutral', 200)};
-    border: ${getThemedBorderWidth(100)} solid ${getThemedColor('neutral', 300)};
-    color: ${getThemedColor('neutral', 500)};
-    cursor: not-allowed !important;
+export const secondaryButtonStyles = css`
+  background-color: ${getThemedColor('neutral', 100)};
+  border: ${getThemedBorderWidth(100)} solid ${getThemedColor('neutral', 300)};
+  color: ${getThemedColor('neutral', 800)};
+  box-shadow: 0 0.0625rem 0.125rem 0 #0000000d;
 
-    &:hover {
-      background-color: ${getThemedColor('neutral', 200)} !important;
-    }
-  `
-    : `
+  &:hover {
     background-color: ${getThemedColor('neutral', 100)};
-    border: ${getThemedBorderWidth(100)} solid ${getThemedColor('neutral', 300)};
-    color: ${getThemedColor('neutral', 800)};
-    box-shadow: 0 0.0625rem 0.125rem 0 #0000000D;
+    box-shadow: 0 0.125rem 0.25rem -0.125rem #0000001a;
+    box-shadow: 0 0.25rem 0.375rem -0.0625rem #0000001a;
+  }
 
-    &:hover {
-      background-color: ${getThemedColor('neutral', 100)};
-      box-shadow: 0 0.125rem 0.25rem -0.125rem #0000001A;
-      box-shadow: 0 0.25rem 0.375rem -0.0625rem #0000001A;
-    }
+  &:active {
+    outline: none;
+    background-color: ${getThemedColor('neutral', 200)} !important;
+    border: ${getThemedBorderWidth(100)} solid ${getThemedColor('neutral', 300)} !important;
+    box-shadow: 0 0.125rem 0.25rem -0.125rem #0000001a;
+    box-shadow: 0 0.25rem 0.375rem -0.0625rem #0000001a;
+  }
 
-    &:active {
-      outline: none;
-      background-color: ${getThemedColor('neutral', 200)} !important;
-      border: ${getThemedBorderWidth(100)} solid ${getThemedColor('neutral', 300)} !important;
-      box-shadow: 0 0.125rem 0.25rem -0.125rem #0000001A;
-      box-shadow: 0 0.25rem 0.375rem -0.0625rem #0000001A;
-    }
+  &:focus-visible {
+    outline-color: ${getThemedColor('primary', 700)};
+  }
 
-    &:focus-visible {
-      outline-color: ${getThemedColor('primary', 700)};
-    }
-  `}
-`
-
-export const borderlessButtonStyles = (disabled?: boolean) => css`
-  ${disabled
-    ? `
-    background-color: transparent;
-    color: ${getThemedColor('neutral', 500)};
-    cursor: not-allowed !important;
-
-    &:hover {
-      background-color: transparent !important;
-    }
-  `
-    : `
-    background-color: transparent;
-    border: none;
-    color: ${getThemedColor('neutral', 900)};
-    box-shadow: none;
-
-    &:hover {
-      background-color: color-mix(in srgb, ${getThemedColor('primary', 500)} 20%, transparent);
-    }
-
-    &:active {
-      outline: none;
-      background-color: color-mix(in srgb, ${getThemedColor('primary', 500)} 40%, transparent);
-      box-shadow: 0 0.25rem 0.375rem -0.0625rem #0000001A;
-    }
-
-    &:focus-visible {
-      outline-color: ${getThemedColor('primary', 700)};
-    }
-  `}
-`
-
-export const outlineButtonStyles = (disabled?: boolean) => css`
-  ${disabled
-    ? `
+  &:disabled,
+  &[data-disabled] {
     background-color: ${getThemedColor('neutral', 200)};
     border: ${getThemedBorderWidth(100)} solid ${getThemedColor('neutral', 300)};
     color: ${getThemedColor('neutral', 500)};
-    cursor: not-allowed !important;
+    cursor: not-allowed;
+    opacity: 1;
 
     &:hover {
-      background-color: ${getThemedColor('neutral', 200)} !important;
+      background-color: ${getThemedColor('neutral', 200)};
     }
-  `
-    : `
+  }
+`
+
+export const borderlessButtonStyles = css`
+  background-color: transparent;
+  border: none;
+  color: ${getThemedColor('neutral', 900)};
+  box-shadow: none;
+
+  &:hover {
+    background-color: color-mix(
+      in srgb,
+      ${getThemedColor('primary', 500)} 20%,
+      transparent
+    );
+  }
+
+  &:active {
+    outline: none;
+    background-color: color-mix(
+      in srgb,
+      ${getThemedColor('primary', 500)} 40%,
+      transparent
+    );
+    box-shadow: 0 0.25rem 0.375rem -0.0625rem #0000001a;
+  }
+
+  &:focus-visible {
+    outline-color: ${getThemedColor('primary', 700)};
+  }
+
+  &:disabled,
+  &[data-disabled] {
     background-color: transparent;
-    border: ${getThemedBorderWidth(100)} solid ${getThemedColor('primary', 800)};
-    color: ${getThemedColor('primary', 800)};
+    color: ${getThemedColor('neutral', 500)};
+    cursor: not-allowed;
+    opacity: 1;
 
     &:hover {
-      background-color: ${getThemedColor('primary', 100)};
-      color: ${getThemedColor('primary', 900)};
+      background-color: transparent;
     }
+  }
+`
 
-    &:active {
-      outline: none;
-      background-color: ${getThemedColor('primary', 200)} !important;
-      border: ${getThemedBorderWidth(100)} solid ${getThemedColor('primary', 900)} !important;
-      color: ${getThemedColor('primary', 900)};
-    }
+export const outlineButtonStyles = css`
+  background-color: transparent;
+  border: ${getThemedBorderWidth(100)} solid ${getThemedColor('primary', 800)};
+  color: ${getThemedColor('primary', 800)};
 
-    &:focus-visible {
-      outline-color: ${getThemedColor('primary', 700)};
-      background-color: ${getThemedColor('primary', 100)};
+  &:hover {
+    background-color: ${getThemedColor('primary', 100)};
+    color: ${getThemedColor('primary', 900)};
+  }
+
+  &:active {
+    outline: none;
+    background-color: ${getThemedColor('primary', 200)} !important;
+    border: ${getThemedBorderWidth(100)} solid ${getThemedColor('primary', 900)} !important;
+    color: ${getThemedColor('primary', 900)};
+  }
+
+  &:focus-visible {
+    outline-color: ${getThemedColor('primary', 700)};
+    background-color: ${getThemedColor('primary', 100)};
+  }
+
+  &:disabled,
+  &[data-disabled] {
+    background-color: ${getThemedColor('neutral', 200)};
+    border: ${getThemedBorderWidth(100)} solid ${getThemedColor('neutral', 300)};
+    color: ${getThemedColor('neutral', 500)};
+    cursor: not-allowed;
+    opacity: 1;
+
+    &:hover {
+      background-color: ${getThemedColor('neutral', 200)};
     }
-  `}
+  }
+`
+
+export const negativeButtonStyles = css`
+  background-color: ${getThemedColor('error', 100)};
+  border: ${getThemedBorderWidth(100)} solid ${getThemedColor('error', 300)};
+  color: ${getThemedColor('accessible', 'text-on-negative-mids') ||
+  getThemedColor('error', 900)};
+  box-shadow: 0 0.0625rem 0.125rem 0 #0000000d;
+
+  &:hover {
+    background-color: ${getThemedColor('error', 100)};
+    box-shadow: 0 0.125rem 0.25rem -0.125rem #0000001a;
+    box-shadow: 0 0.25rem 0.375rem -0.0625rem #0000001a;
+  }
+
+  &:active {
+    outline: none;
+    background-color: ${getThemedColor('error', 400)} !important;
+    box-shadow: 0 0.125rem 0.25rem -0.125rem #0000001a;
+    box-shadow: 0 0.25rem 0.375rem -0.0625rem #0000001a;
+  }
+
+  &:focus-visible {
+    outline-color: ${getThemedColor('primary', 700)};
+  }
+
+  &:disabled,
+  &[data-disabled] {
+    background-color: ${getThemedColor('neutral', 200)};
+    border: ${getThemedBorderWidth(100)} solid ${getThemedColor('neutral', 300)};
+    color: ${getThemedColor('neutral', 500)};
+    cursor: not-allowed;
+    opacity: 1;
+  }
 `

--- a/src/components/Forms/Actions/Button/types.ts
+++ b/src/components/Forms/Actions/Button/types.ts
@@ -10,7 +10,7 @@ export type ButtonProps = Omit<
 > & {
   label?: string
   loading?: boolean
-  variant?: 'primary' | 'secondary' | 'borderless' | 'outline'
+  variant?: 'primary' | 'secondary' | 'borderless' | 'outline' | 'negative'
   size?: 'default' | 'small'
   disabled?: boolean
   leftIcon?: React.ReactNode

--- a/src/components/Forms/Actions/MultiActionButton/MultiActionButton.stories.tsx
+++ b/src/components/Forms/Actions/MultiActionButton/MultiActionButton.stories.tsx
@@ -3,7 +3,6 @@ import React from 'react'
 
 /* eslint-disable no-console */
 import type { Meta, StoryObj } from '@storybook/react'
-import { fn } from '@storybook/test'
 import MultiActionButton from '.'
 import { InfoIcon } from '../../../icons'
 
@@ -21,12 +20,11 @@ const meta = {
     },
   },
   tags: ['autodocs'],
-  args: { onClick: fn() },
   argTypes: {
     variant: {
       description: 'Visual style of the button',
       control: { type: 'select' },
-      options: ['primary', 'secondary'],
+      options: ['primary', 'secondary', 'borderless', 'outline', 'negative'],
     },
     size: {
       description: 'Size variant',
@@ -142,6 +140,129 @@ export const SecondarySmall: Story = {
   },
 }
 
+export const BorderlessDefault: Story = {
+  args: {
+    variant: 'borderless',
+    mainActionLabel: 'First Action',
+    mainActionOnClick: () => console.log('first action'),
+    otherActions: [
+      {
+        label: 'Second Action',
+        value: 'second-action',
+        onClick: () => console.log('second action'),
+      },
+      {
+        label: 'Third Action',
+        value: 'third-action',
+        onClick: () => console.log('third action'),
+      },
+    ],
+  },
+}
+
+export const BorderlessSmall: Story = {
+  args: {
+    variant: 'borderless',
+    size: 'small',
+    mainActionLabel: 'First Action',
+    mainActionOnClick: () => console.log('first action'),
+    otherActions: [
+      {
+        label: 'Second Action',
+        value: 'second-action',
+        onClick: () => console.log('second action'),
+      },
+      {
+        label: 'Third Action',
+        value: 'third-action',
+        onClick: () => console.log('third action'),
+      },
+    ],
+  },
+}
+
+export const OutlineDefault: Story = {
+  args: {
+    variant: 'outline',
+    mainActionLabel: 'First Action',
+    mainActionOnClick: () => console.log('first action'),
+    otherActions: [
+      {
+        label: 'Second Action',
+        value: 'second-action',
+        onClick: () => console.log('second action'),
+      },
+      {
+        label: 'Third Action',
+        value: 'third-action',
+        onClick: () => console.log('third action'),
+      },
+    ],
+  },
+}
+
+export const OutlineSmall: Story = {
+  args: {
+    variant: 'outline',
+    size: 'small',
+    mainActionLabel: 'First Action',
+    mainActionOnClick: () => console.log('first action'),
+    otherActions: [
+      {
+        label: 'Second Action',
+        value: 'second-action',
+        onClick: () => console.log('second action'),
+      },
+      {
+        label: 'Third Action',
+        value: 'third-action',
+        onClick: () => console.log('third action'),
+      },
+    ],
+  },
+}
+
+export const NegativeDefault: Story = {
+  args: {
+    variant: 'negative',
+    mainActionLabel: 'First Action',
+    mainActionOnClick: () => console.log('first action'),
+    otherActions: [
+      {
+        label: 'Second Action',
+        value: 'second-action',
+        onClick: () => console.log('second action'),
+      },
+      {
+        label: 'Third Action',
+        value: 'third-action',
+        onClick: () => console.log('third action'),
+      },
+    ],
+  },
+}
+
+export const NegativeSmall: Story = {
+  args: {
+    variant: 'negative',
+    size: 'small',
+    mainActionLabel: 'First Action',
+    mainActionOnClick: () => console.log('first action'),
+    otherActions: [
+      {
+        label: 'Second Action',
+        value: 'second-action',
+        onClick: () => console.log('second action'),
+      },
+      {
+        label: 'Third Action',
+        value: 'third-action',
+        onClick: () => console.log('third action'),
+      },
+    ],
+  },
+}
+
 export const Disabled: Story = {
   args: {
     variant: 'primary',
@@ -160,6 +281,27 @@ export const Disabled: Story = {
       },
     ],
     disabled: true,
+  },
+}
+
+export const WithDisabledMenuItem: Story = {
+  args: {
+    variant: 'primary',
+    mainActionLabel: 'First Action',
+    mainActionOnClick: () => console.log('first action'),
+    otherActions: [
+      {
+        label: 'Second Action',
+        value: 'second-action',
+        onClick: () => console.log('second action'),
+      },
+      {
+        label: 'Third Action',
+        value: 'third-action',
+        onClick: () => console.log('third action'),
+        disabled: true,
+      },
+    ],
   },
 }
 

--- a/src/components/Forms/Actions/MultiActionButton/MultiActionButtonDemo.tsx
+++ b/src/components/Forms/Actions/MultiActionButton/MultiActionButtonDemo.tsx
@@ -35,6 +35,7 @@ const MultiActionButtonDemo = () => (
               label: 'Third Action',
               value: 'third-action',
               onClick: () => console.log('third action'),
+              disabled: true,
             },
           ]}
         />
@@ -74,6 +75,108 @@ const MultiActionButtonDemo = () => (
         />
         <MultiActionButton
           variant='secondary'
+          size='small'
+          mainActionLabel='First Action'
+          mainActionOnClick={() => console.log('first action')}
+          otherActions={[
+            {
+              label: 'Second Action',
+              value: 'second-action',
+              onClick: () => console.log('second action'),
+            },
+          ]}
+        />
+      </div>
+      <div
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          gap: '0.625rem',
+          flexWrap: 'wrap',
+        }}
+      >
+        <MultiActionButton
+          variant='borderless'
+          mainActionLabel='First Action'
+          mainActionOnClick={() => console.log('first action')}
+          otherActions={[
+            {
+              label: 'Second Action',
+              value: 'second-action',
+              onClick: () => console.log('second action'),
+            },
+          ]}
+        />
+        <MultiActionButton
+          variant='borderless'
+          size='small'
+          mainActionLabel='First Action'
+          mainActionOnClick={() => console.log('first action')}
+          otherActions={[
+            {
+              label: 'Second Action',
+              value: 'second-action',
+              onClick: () => console.log('second action'),
+            },
+          ]}
+        />
+      </div>
+      <div
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          gap: '0.625rem',
+          flexWrap: 'wrap',
+        }}
+      >
+        <MultiActionButton
+          variant='outline'
+          mainActionLabel='First Action'
+          mainActionOnClick={() => console.log('first action')}
+          otherActions={[
+            {
+              label: 'Second Action',
+              value: 'second-action',
+              onClick: () => console.log('second action'),
+            },
+          ]}
+        />
+        <MultiActionButton
+          variant='outline'
+          size='small'
+          mainActionLabel='First Action'
+          mainActionOnClick={() => console.log('first action')}
+          otherActions={[
+            {
+              label: 'Second Action',
+              value: 'second-action',
+              onClick: () => console.log('second action'),
+            },
+          ]}
+        />
+      </div>
+      <div
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          gap: '0.625rem',
+          flexWrap: 'wrap',
+        }}
+      >
+        <MultiActionButton
+          variant='negative'
+          mainActionLabel='First Action'
+          mainActionOnClick={() => console.log('first action')}
+          otherActions={[
+            {
+              label: 'Second Action',
+              value: 'second-action',
+              onClick: () => console.log('second action'),
+            },
+          ]}
+        />
+        <MultiActionButton
+          variant='negative'
           size='small'
           mainActionLabel='First Action'
           mainActionOnClick={() => console.log('first action')}

--- a/src/components/Forms/Actions/MultiActionButton/README.md
+++ b/src/components/Forms/Actions/MultiActionButton/README.md
@@ -39,7 +39,7 @@ type MultiActionButtonProps = Omit<
   ChakraButtonProps,
   'size' | 'variant' | 'colorPalette' | 'children'
 > & {
-  variant?: 'primary' | 'secondary'
+  variant?: 'primary' | 'secondary' | 'outline' | 'borderless' | 'negative'
   size?: 'default' | 'small'
   mainActionLeftIcon?: React.ReactNode
   mainActionRightIcon?: React.ReactNode

--- a/src/components/Forms/Actions/MultiActionButton/index.tsx
+++ b/src/components/Forms/Actions/MultiActionButton/index.tsx
@@ -12,8 +12,8 @@ import {
   menuItemStyles,
   disabledGroupStyles,
   triggerMenuButtonStyles,
+  getMenuTriggerIconColor,
 } from './styled'
-import { getThemedColor } from '../../../../lib/theme'
 
 interface MenuContentProps extends ChakraMenu.ContentProps {
   portalled?: boolean
@@ -60,7 +60,7 @@ const MultiActionButton = ({
       role='group'
     >
       <Button
-        css={{}}
+        {...rest}
         label={mainActionLabel}
         variant={variant}
         size={size}
@@ -68,12 +68,17 @@ const MultiActionButton = ({
         disabled={isDisabledProp}
         leftIcon={mainActionLeftIcon}
         rightIcon={mainActionRightIcon}
-        {...rest}
       />
 
       <ChakraMenu.Root
         onOpenChange={({ open }) => setIsOpen(open)}
         positioning={{ placement: 'bottom-end' }}
+        onSelect={({ value }) => {
+          const action = otherActions.find((item) => item.value === value)
+          if (action && !action.disabled) {
+            action.onClick()
+          }
+        }}
       >
         <ChakraMenu.Trigger
           css={menuTriggerStyles(variant)}
@@ -92,22 +97,19 @@ const MultiActionButton = ({
               <ChevronDownIcon
                 aria-hidden='true'
                 rotate={isOpen ? '180' : '0'}
-                color={
-                  getThemedColor('accessible', 'text-on-primary-mids') ||
-                  getThemedColor('primary', 900)
-                }
+                color={getMenuTriggerIconColor(variant, isDisabledProp)}
               />
             }
             disabled={isDisabledProp}
           />
         </ChakraMenu.Trigger>
         <MenuContent>
-          {otherActions.map(({ label, value, onClick }) => (
+          {otherActions.map(({ label, value, disabled }) => (
             <ChakraMenu.Item
               css={menuItemStyles(size)}
               key={value}
-              onClick={onClick}
               value={value}
+              disabled={disabled}
             >
               {label}
             </ChakraMenu.Item>

--- a/src/components/Forms/Actions/MultiActionButton/styled.ts
+++ b/src/components/Forms/Actions/MultiActionButton/styled.ts
@@ -17,14 +17,77 @@ export const menuContentStyles = css`
   padding: ${getThemedSpacing(200)};
 `
 
+const getMenuTriggerOpenBackgroundColor = (
+  variant: MultiActionButtonProps['variant'],
+) => {
+  switch (variant) {
+    case 'secondary':
+      return getThemedColor('neutral', 200)
+    case 'borderless':
+      return `color-mix(in srgb, ${getThemedColor('primary', 500)} 40%, transparent)`
+    case 'outline':
+      return getThemedColor('primary', 200)
+    case 'negative':
+      return getThemedColor('error', 600)
+    case 'primary':
+    default:
+      return getThemedColor('primary', 600)
+  }
+}
+
+const getMenuTriggerOpenBorderColor = (
+  variant: MultiActionButtonProps['variant'],
+) => {
+  switch (variant) {
+    case 'secondary':
+      return getThemedColor('primary', 800)
+    case 'borderless':
+      return 'transparent'
+    case 'outline':
+      return getThemedColor('primary', 900)
+    case 'negative':
+      return getThemedColor('primary', 800)
+    case 'primary':
+    default:
+      return getThemedColor('primary', 800)
+  }
+}
+
+export const getMenuTriggerIconColor = (
+  variant: MultiActionButtonProps['variant'],
+  disabled?: boolean,
+) => {
+  if (disabled) return getThemedColor('neutral', 500)
+
+  switch (variant) {
+    case 'secondary':
+      return getThemedColor('neutral', 800)
+    case 'borderless':
+      return getThemedColor('neutral', 900)
+    case 'outline':
+      return getThemedColor('primary', 800)
+    case 'negative':
+      return (
+        getThemedColor('accessible', 'text-on-negative-mids') ||
+        getThemedColor('error', 900)
+      )
+    case 'primary':
+    default:
+      return (
+        getThemedColor('accessible', 'text-on-primary-mids') ||
+        getThemedColor('primary', 900)
+      )
+  }
+}
+
 export const menuTriggerStyles = (
   variant: MultiActionButtonProps['variant'],
 ) => css`
   &[data-state='open'] {
-    background-color: ${variant === 'primary'
-      ? getThemedColor('primary', 600)
-      : getThemedColor('neutral', 200)} !important;
-    border: ${getThemedBorderWidth(100)} solid ${getThemedColor('primary', 800)} !important;
+    background-color: ${getMenuTriggerOpenBackgroundColor(variant)} !important;
+    border: ${variant === 'borderless'
+      ? 'none'
+      : `${getThemedBorderWidth(100)} solid ${getMenuTriggerOpenBorderColor(variant)}`} !important;
   }
 `
 
@@ -41,6 +104,11 @@ export const menuItemStyles = (size: MultiActionButtonProps['size']) => css`
 
   &[data-highlighted] {
     background-color: ${getThemedColor('neutral', 200)};
+  }
+
+  &[data-disabled] {
+    cursor: not-allowed;
+    color: ${getThemedColor('neutral', 500)};
   }
 `
 export const disabledGroupStyles = css`

--- a/src/components/Forms/Actions/MultiActionButton/types.ts
+++ b/src/components/Forms/Actions/MultiActionButton/types.ts
@@ -1,12 +1,10 @@
-import { ButtonProps as ChakraButtonProps } from '@chakra-ui/react'
 import React from 'react'
+import { ButtonProps } from '../Button/types'
 
 export type MultiActionButtonProps = Omit<
-  ChakraButtonProps,
-  'size' | 'variant' | 'colorPalette' | 'children'
+  ButtonProps,
+  'label' | 'leftIcon' | 'rightIcon' | 'onClick' | 'children' | 'css'
 > & {
-  variant?: 'primary' | 'secondary'
-  size?: 'default' | 'small'
   mainActionLeftIcon?: React.ReactNode
   mainActionRightIcon?: React.ReactNode
   mainActionLabel: string
@@ -15,6 +13,6 @@ export type MultiActionButtonProps = Omit<
     label: React.ReactNode
     value: string
     onClick: VoidFunction
+    disabled?: boolean
   }[]
-  disabled?: boolean
 }

--- a/src/lib/theme.ts
+++ b/src/lib/theme.ts
@@ -116,7 +116,6 @@ export const wriColors: ThemeColors = {
     100: { value: '#FFEFED' },
     200: { value: '#EDA1A9' },
     300: { value: '#F6C5C1' },
-    400: { value: '#F9D6D4' },
     500: { value: '#C11101' },
     900: { value: '#8D0D01' },
   },

--- a/src/lib/theme.ts
+++ b/src/lib/theme.ts
@@ -116,12 +116,14 @@ export const wriColors: ThemeColors = {
     100: { value: '#FFEFED' },
     200: { value: '#EDA1A9' },
     300: { value: '#F6C5C1' },
+    400: { value: '#F9D6D4' },
     500: { value: '#C11101' },
     900: { value: '#8D0D01' },
   },
   accessible: {
     'text-on-primary-mids': { value: '#332300' }, // primary 900
     'text-on-secondary-mids': { value: '#F2F6FF' }, // secondary 100
+    'text-on-negative-mids': { value: '#8D0D01' }, // error 900
     'controls-on-neutral-lights': { value: '#855B00' }, // primary 700
     'controls-on-neutral-darks': { value: '#F5BF4F' }, // primary 400
   },
@@ -243,7 +245,8 @@ export const getThemedColor = (
     | 'text-on-primary-mids'
     | 'text-on-secondary-mids'
     | 'controls-on-neutral-lights'
-    | 'controls-on-neutral-darks',
+    | 'controls-on-neutral-darks'
+    | 'text-on-negative-mids',
 ): string =>
   designSystemStyles.tokens.getVar(`colors.${variant}.${index}`) ||
   wriColors?.[variant]?.[index]?.value


### PR DESCRIPTION
What
Adds negative and outline button variants, refactors disabled styling to use CSS pseudo-selectors, and fixes MultiActionButton menu selection and prop typing.

Why
The design system needed destructive (negative) and bordered (outline) button styles across Button and MultiActionButton. Disabled states were previously driven by a JS disabled prop passed into style functions, which duplicated logic and didn't align with DOM state. MultiActionButton also had bugs where disabled menu items still fired handlers and Storybook spies caused misleading performance warnings.

Changes
Button
Added negative variant with new negativeButtonStyles and theme token text-on-negative-mids
Refactored all variant styles (primary, secondary, borderless, outline, negative) from (disabled?: boolean) => css to static CSS blocks using :disabled and [data-disabled]
Updated Button to apply styles without passing disabled into style functions
Added negative to types, demo, stories, README, and a11y test
Removed Storybook fn() default onClick spy to avoid dev-only performance violations
Before:

css={[baseButtonStyles(size), variantButtonStyles(disabled)]}
After:

css={[baseButtonStyles(size), variantButtonStyles]}
MultiActionButton
Extended variant support to outline, borderless, and negative (matching Button)
Added variant-aware menu trigger open states and chevron icon colors
Fixed disabled menu items by routing actions through Menu.Root onSelect instead of onClick on Menu.Item
Added WithDisabledMenuItem story and disabled menu item styles
Fixed main action prop spread order so mainActionOnClick is not overridden by rest
Updated types to extend ButtonProps and omit incompatible props (css, onClick, etc.)
Before:

<ChakraMenu.Item onClick={onClick} disabled={disabled} />
After:

<ChakraMenu.Root onSelect={({ value }) => { /* skip disabled */ }} />
<ChakraMenu.Item value={value} disabled={disabled} />
Theme
Added error.400 and accessible.text-on-negative-mids tokens