### PR TITLE
[DS-327] Fix Container Components

### DIFF
--- a/src/components/Containers/Modal/Modal.stories.tsx
+++ b/src/components/Containers/Modal/Modal.stories.tsx
@@ -4,7 +4,13 @@ import React, { useState } from 'react'
 import type { Meta, StoryObj } from '@storybook/react'
 import ModalStory from '.'
 import Button from '../../Forms/Actions/Button'
-import { getThemedColor } from '../../../lib/theme'
+import { getThemedColor, getThemedSpacing } from '../../../lib/theme'
+
+const paddedContent = (
+  <div style={{ padding: getThemedSpacing(300) }}>
+    <p>Content</p>
+  </div>
+)
 
 const meta = {
   title: 'Containers/Modal',
@@ -61,7 +67,7 @@ export const Modal: Story = {
         Title
       </p>
     ),
-    content: <p>Content</p>,
+    content: paddedContent,
     open: false,
   },
   render: (args) => {
@@ -92,7 +98,7 @@ export const ExtraSmall: Story = {
         Title
       </p>
     ),
-    content: <p>Content</p>,
+    content: paddedContent,
     size: 'xsmall',
     open: false,
   },
@@ -124,7 +130,7 @@ export const Small: Story = {
         Title
       </p>
     ),
-    content: <p>Content</p>,
+    content: paddedContent,
     size: 'small',
     open: false,
   },
@@ -156,7 +162,7 @@ export const Large: Story = {
         Title
       </p>
     ),
-    content: <p>Content</p>,
+    content: paddedContent,
     size: 'large',
     open: false,
   },
@@ -188,7 +194,7 @@ export const ExtraLarge: Story = {
         Title
       </p>
     ),
-    content: <p>Content</p>,
+    content: paddedContent,
     size: 'xlarge',
     open: false,
   },
@@ -219,7 +225,7 @@ export const FullWidth: Story = {
         Title
       </p>
     ),
-    content: <p>Content</p>,
+    content: paddedContent,
     size: 'full-width',
     open: false,
   },
@@ -251,7 +257,7 @@ export const CustomSize: Story = {
         Title
       </p>
     ),
-    content: <p>Content</p>,
+    content: paddedContent,
     width: '31.25rem',
     height: '18.75rem',
     maxHeight: '25rem',
@@ -285,7 +291,7 @@ export const WithActions: Story = {
         Title
       </p>
     ),
-    content: <p>Content</p>,
+    content: paddedContent,
     open: false,
   },
   render: (args) => {
@@ -333,7 +339,7 @@ export const Draggable: Story = {
         Title
       </p>
     ),
-    content: <p>Content</p>,
+    content: paddedContent,
     open: false,
   },
   render: (args) => {
@@ -365,7 +371,7 @@ export const Blocking: Story = {
         Title
       </p>
     ),
-    content: <p>Content</p>,
+    content: paddedContent,
     open: false,
   },
   render: (args) => {

--- a/src/components/Containers/Modal/Modal.test.tsx
+++ b/src/components/Containers/Modal/Modal.test.tsx
@@ -1,6 +1,7 @@
 import { render } from '@testing-library/react'
 import { axe } from 'jest-axe'
 
+import { getThemedSpacing } from '../../../lib/theme'
 import Modal from '.'
 
 jest.mock('react-draggable', () => ({
@@ -19,7 +20,11 @@ describe('Modal — accessibility', () => {
         open
         onClose={() => {}}
         header={<p>Modal title</p>}
-        content={<p>Modal content</p>}
+        content={
+          <div style={{ padding: getThemedSpacing(300) }}>
+            <p>Modal content</p>
+          </div>
+        }
         footer={<button type='button'>Save</button>}
       />,
     )

--- a/src/components/Containers/Modal/ModalDemo.tsx
+++ b/src/components/Containers/Modal/ModalDemo.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react'
-import { Button, getThemedColor, Modal } from '../..'
+import { Button, getThemedColor, getThemedSpacing, Modal } from '../..'
 import DemoWrapper from '../../UI/DemoWrapper'
 import { ModalProps } from './types'
 
@@ -26,7 +26,11 @@ const ModalDemo = () => {
           Title
         </p>
       ),
-      content: <p>Modal size: {size}</p>,
+      content: (
+        <div style={{ padding: getThemedSpacing(300) }}>
+          <p>Modal size: {size}</p>
+        </div>
+      ),
       footer: showActions ? (
         <>
           <Button

--- a/src/components/Containers/Modal/README.md
+++ b/src/components/Containers/Modal/README.md
@@ -59,7 +59,11 @@ type ModalProps = {
       Title
     </p>
   }
-  content={<p>Content</p>}
+  content={
+    <div style={{ padding: getThemedSpacing(300) }}>
+      <p>Content</p>
+    </div>
+  }
   open={showModal}
   onClose={() => setShowModal(false)}
 />
@@ -79,15 +83,10 @@ type ModalProps = {
       Title
     </p>
   }
-  header={
-    <p
-      style={{
-        fontWeight: 'bold',
-        color: getThemedColor('neutral', 800),
-      }}
-    >
-      Title
-    </p>
+  content={
+    <div style={{ padding: getThemedSpacing(300) }}>
+      <p>Content</p>
+    </div>
   }
   size='small'
   open={showModal}
@@ -109,7 +108,11 @@ type ModalProps = {
       Title
     </p>
   }
-  content={<p>Content</p>}
+  content={
+    <div style={{ padding: getThemedSpacing(300) }}>
+      <p>Content</p>
+    </div>
+  }
   size='large'
   open={showModal}
   onClose={() => setShowModal(false)}
@@ -130,7 +133,11 @@ type ModalProps = {
       Title
     </p>
   }
-  content={<p>Content</p>}
+  content={
+    <div style={{ padding: getThemedSpacing(300) }}>
+      <p>Content</p>
+    </div>
+  }
   size='xlarge'
   open={showModal}
   onClose={() => setShowModal(false)}
@@ -151,7 +158,11 @@ type ModalProps = {
       Title
     </p>
   }
-  content={<p>Content</p>}
+  content={
+    <div style={{ padding: getThemedSpacing(300) }}>
+      <p>Content</p>
+    </div>
+  }
   footer={
     <>
       <Button
@@ -188,7 +199,11 @@ type ModalProps = {
       Title
     </p>
   }
-  content={<p>Content</p>}
+  content={
+    <div style={{ padding: getThemedSpacing(300) }}>
+      <p>Content</p>
+    </div>
+  }
   open={showModal}
   onClose={() => setShowModal(false)}
   draggable
@@ -209,7 +224,11 @@ type ModalProps = {
       Title
     </p>
   }
-  content={<p>Content</p>}
+  content={
+    <div style={{ padding: getThemedSpacing(300) }}>
+      <p>Content</p>
+    </div>
+  }
   open={showModal}
   onClose={() => setShowModal(false)}
   blocking

--- a/src/components/Containers/Modal/styled.ts
+++ b/src/components/Containers/Modal/styled.ts
@@ -74,5 +74,5 @@ export const modalCloseButtonStyles = css`
 `
 
 export const modalContentStyles = css`
-  padding: ${getThemedSpacing(300)};
+  padding: 0;
 `


### PR DESCRIPTION
What
Removes hard-coded body padding from Modal and moves spacing into consumer content so edge-to-edge layouts are possible.

Why
Container slots should not force default padding. Consumers need to opt into spacing when building banners, images, or custom layouts.

Changes
Set modalContentStyles padding to 0 in Modal/styled.ts
Apply former default padding (getThemedSpacing(300)) on content in Modal usages:
ModalDemo.tsx
Modal.stories.tsx (shared paddedContent helper)
Modal.test.tsx
README.md examples
Fix the broken Small README example (duplicate header, missing content)
Before:

// Modal applied padding internally
export const modalContentStyles = css`
  padding: ${getThemedSpacing(300)};
`
content={<p>Content</p>}
After:


// Modal body is unpadded; consumers control spacing
export const modalContentStyles = css`
  padding: 0;
`
content={
  <div style={{ padding: getThemedSpacing(300) }}>
    <p>Content</p>
  </div>
}