### PR TITLE
[DS-326] refactor: standardize form inputs with FieldWrapper

### DIFF
--- a/src/components/Forms/Controls/Checkbox/styled.ts
+++ b/src/components/Forms/Controls/Checkbox/styled.ts
@@ -4,6 +4,7 @@ import {
   getThemedColor,
   getThemedSpacing,
 } from '../../../../lib/theme'
+import { fieldFocusVisibleStyles } from '../../Inputs/FieldWrapper/styled'
 
 export const checkboxStyles = css`
   .chakra-checkbox__control {
@@ -34,13 +35,7 @@ export const checkboxStyles = css`
 
     &:focus-visible,
     &[data-focus-visible] {
-      box-shadow: none;
-      outline: ${getThemedBorderWidth(200)} solid
-        ${getThemedColor('primary', 700)};
-      outline-offset: ${getThemedSpacing(50)};
-      box-shadow:
-        0 0 0 0.125rem ${getThemedColor('neutral', 100)},
-        rgba(0, 0, 0, 0.05) 0 0.125rem 0.125rem 0.25rem;
+      ${fieldFocusVisibleStyles}
     }
 
     &[data-state='checked'],

--- a/src/components/Forms/Controls/Radio/styled.ts
+++ b/src/components/Forms/Controls/Radio/styled.ts
@@ -4,6 +4,7 @@ import {
   getThemedColor,
   getThemedSpacing,
 } from '../../../../lib/theme'
+import { fieldFocusVisibleStyles } from '../../Inputs/FieldWrapper/styled'
 
 export const radioGroupItemStyles = css`
   .ds-radio-item-indicator {
@@ -30,13 +31,7 @@ export const radioGroupItemStyles = css`
 
     &:focus-visible,
     &[data-focus-visible] {
-      outline: ${getThemedBorderWidth(200)} solid
-        ${getThemedColor('accessible', 'controls-on-neutral-lights') ||
-        getThemedColor('primary', 700)};
-      outline-offset: ${getThemedSpacing(50)};
-      box-shadow:
-        0 0 0 0.125rem ${getThemedColor('neutral', 100)},
-        rgba(0, 0, 0, 0.05) 0 0.125rem 0.125rem 0.25rem;
+      ${fieldFocusVisibleStyles}
 
       &[data-checked] {
         border: ${getThemedBorderWidth(200)} solid

--- a/src/components/Forms/Controls/Slider/styled.ts
+++ b/src/components/Forms/Controls/Slider/styled.ts
@@ -7,6 +7,7 @@ import {
   getThemedRadius,
   getThemedSpacing,
 } from '../../../../lib/theme'
+import { fieldFocusVisibleStyles } from '../../Inputs/FieldWrapper/styled'
 
 export const sliderRootStyles = css`
   height: 3.75rem;
@@ -42,12 +43,7 @@ export const sliderThumbStyles = css`
 
   &:focus-visible,
   &[data-focus-visible] {
-    outline: ${getThemedBorderWidth(200)} solid
-      ${getThemedColor('primary', 700)};
-    outline-offset: ${getThemedSpacing(50)};
-    box-shadow:
-      0 0 0 0.125rem ${getThemedColor('neutral', 100)},
-      rgba(0, 0, 0, 0.05) 0 0.125rem 0.125rem 0.25rem;
+    ${fieldFocusVisibleStyles}
 
     .ds-slider-value-preview {
       display: flex;

--- a/src/components/Forms/Inputs/CheckboxList/index.tsx
+++ b/src/components/Forms/Inputs/CheckboxList/index.tsx
@@ -2,22 +2,17 @@
 /** @jsxImportSource @emotion/react */
 
 import { useEffect, useMemo, useState } from 'react'
-import { Group } from '@chakra-ui/react'
 import { CheckboxListProps } from './types'
 import { useLabels } from '../../../../lib/i18n/useLabels'
 import Checkbox from '../../Controls/Checkbox'
 import { ChevronDownIcon } from '../../../icons'
 import {
-  checkboxListCaptionStyles,
-  checkboxListContainerStyles,
   checkboxListContentListStyles,
-  checkboxListContentStyles,
-  checkboxListErrorBarStyles,
-  checkboxListErrorMessageStyles,
-  checkboxListLabelStyles,
   checkboxCounterTextStyles,
   expandButtonStyles,
+  checkboxListLabelRowStyles,
 } from './styled'
+import FieldWrapper from '../FieldWrapper'
 
 const CheckboxList = ({
   label,
@@ -159,106 +154,89 @@ const CheckboxList = ({
     : ''
 
   const groupLabel = `${hasParentCheckbox ? label.label : label}. ${captionText} ${requiredText} ${errorText} `
-  return (
-    <Group css={checkboxListContainerStyles} aria-label={groupLabel}>
-      {errorMessage ? <div css={checkboxListErrorBarStyles} /> : null}
-      <div css={checkboxListContentStyles(!!errorMessage)}>
-        <div css={checkboxListLabelStyles}>
-          {typeof label === 'string' ? (
-            <>
-              {required && (
-                <span
-                  id='required-symbol'
-                  aria-label={resolvedLabels.requiredSymbolLabel}
-                >
-                  *
-                </span>
-              )}
-              {label}
-            </>
-          ) : (
-            <div
-              style={{
-                display: 'flex',
-                alignItems: 'center',
-                justifyContent: 'space-between',
-                width: '100%',
-              }}
-            >
-              <Checkbox
-                checked={allChecked}
-                indeterminate={indeterminate}
-                onCheckedChange={(event) => handleToggleAll(!!event.checked)}
-              >
-                {label.label}{' '}
-                {!hideCheckedCounter && (
-                  <span aria-hidden='true' css={checkboxCounterTextStyles}>
-                    {counterText}
-                  </span>
-                )}
-              </Checkbox>
-              {!hideExpandToggle && (
-                <button
-                  type='button'
-                  onClick={() => setIsExpanded((prev) => !prev)}
-                  aria-expanded={isExpanded}
-                  aria-controls='checkbox-list'
-                  css={expandButtonStyles}
-                >
-                  {isExpanded
-                    ? resolvedLabels.hideLabel
-                    : resolvedLabels.expandLabel}
-                  <span aria-hidden='true'>
-                    {isExpanded ? (
-                      <ChevronDownIcon
-                        style={{ transform: 'rotate(180deg)' }}
-                      />
-                    ) : (
-                      <ChevronDownIcon />
-                    )}
-                  </span>
-                </button>
-              )}
-            </div>
-          )}
-        </div>
-        <p css={checkboxListCaptionStyles} aria-label={caption}>
-          {caption}
-        </p>
-        {errorMessage ? (
-          <p css={checkboxListErrorMessageStyles} aria-label={errorMessage}>
-            {errorMessage}
-          </p>
-        ) : null}
-        <div
-          id='checkbox-list'
-          css={checkboxListContentListStyles(horizontal, isExpanded)}
-        >
-          {checkboxes.map((checkbox) => {
-            const { onCheckedChange: itemOnCheckedChange, ...checkboxProps } =
-              checkbox
 
-            return (
-              <Checkbox
-                ms={hasParentCheckbox && !horizontal ? '6' : ''}
-                key={checkbox.name}
-                css={{}}
-                checked={
-                  checkbox?.name
-                    ? !!resolvedCheckedValues[checkbox.name]
-                    : false
-                }
-                onCheckedChange={({ checked }) => {
-                  handleOnChecked(checked, checkbox.name)
-                  itemOnCheckedChange?.({ checked: !!checked })
-                }}
-                {...checkboxProps}
-              />
-            )
-          })}
-        </div>
+  const labelContent =
+    typeof label === 'string' ? (
+      label
+    ) : (
+      <div css={checkboxListLabelRowStyles}>
+        <Checkbox
+          checked={allChecked}
+          indeterminate={indeterminate}
+          onCheckedChange={(event) => handleToggleAll(!!event.checked)}
+        >
+          {label.label}{' '}
+          {!hideCheckedCounter && (
+            <span aria-hidden='true' css={checkboxCounterTextStyles}>
+              {counterText}
+            </span>
+          )}
+        </Checkbox>
+        {!hideExpandToggle && (
+          <button
+            type='button'
+            onClick={() => setIsExpanded((prev) => !prev)}
+            aria-expanded={isExpanded}
+            aria-controls='checkbox-list'
+            css={expandButtonStyles}
+          >
+            {isExpanded
+              ? resolvedLabels.hideLabel
+              : resolvedLabels.expandLabel}
+            <span aria-hidden='true'>
+              {isExpanded ? (
+                <ChevronDownIcon style={{ transform: 'rotate(180deg)' }} />
+              ) : (
+                <ChevronDownIcon />
+              )}
+            </span>
+          </button>
+        )}
       </div>
-    </Group>
+    )
+
+  return (
+    <FieldWrapper
+      label={labelContent}
+      caption={caption}
+      errorMessage={errorMessage}
+      required={typeof label === 'string' ? required : false}
+      showOptionalLabel={false}
+      noMarginBottom
+      semantics='group'
+      labels={{
+        requiredSymbolLabel: resolvedLabels.requiredSymbolLabel,
+      }}
+      containerProps={{
+        'aria-label': groupLabel,
+      }}
+    >
+      <div
+        id='checkbox-list'
+        css={checkboxListContentListStyles(horizontal, isExpanded)}
+      >
+        {checkboxes.map((checkbox) => {
+          const { onCheckedChange: itemOnCheckedChange, ...checkboxProps } =
+            checkbox
+
+          return (
+            <Checkbox
+              ms={hasParentCheckbox && !horizontal ? '6' : ''}
+              key={checkbox.name}
+              css={{}}
+              checked={
+                checkbox?.name ? !!resolvedCheckedValues[checkbox.name] : false
+              }
+              onCheckedChange={({ checked }) => {
+                handleOnChecked(checked, checkbox.name)
+                itemOnCheckedChange?.({ checked: !!checked })
+              }}
+              {...checkboxProps}
+            />
+          )
+        })}
+      </div>
+    </FieldWrapper>
   )
 }
 

--- a/src/components/Forms/Inputs/CheckboxList/index.tsx
+++ b/src/components/Forms/Inputs/CheckboxList/index.tsx
@@ -180,9 +180,7 @@ const CheckboxList = ({
             aria-controls='checkbox-list'
             css={expandButtonStyles}
           >
-            {isExpanded
-              ? resolvedLabels.hideLabel
-              : resolvedLabels.expandLabel}
+            {isExpanded ? resolvedLabels.hideLabel : resolvedLabels.expandLabel}
             <span aria-hidden='true'>
               {isExpanded ? (
                 <ChevronDownIcon style={{ transform: 'rotate(180deg)' }} />

--- a/src/components/Forms/Inputs/CheckboxList/styled.ts
+++ b/src/components/Forms/Inputs/CheckboxList/styled.ts
@@ -2,48 +2,13 @@ import { css } from '@emotion/react'
 import {
   getThemedColor,
   getThemedFontSize,
-  getThemedLineHeight,
   getThemedSpacing,
 } from '../../../../lib/theme'
-
-export const checkboxListContainerStyles = css`
-  position: relative;
-  height: 100%;
-  width: 100%;
-  &:focus-visible {
-    outline-color: ${getThemedColor('primary', 700)};
-  }
-`
-
-export const checkboxListContentStyles = (hasErrorMessage: boolean) => css`
-  margin-left: ${hasErrorMessage ? '1.1875rem' : '0'};
-  width: 100%;
-`
-
-export const checkboxListLabelStyles = css`
-  font-size: ${getThemedFontSize(400)};
-  line-height: ${getThemedLineHeight(600)};
-  color: ${getThemedColor('neutral', 900)};
-  text-align: left;
-  width: 100%;
-  #required-symbol {
-    color: ${getThemedColor('error', 500)};
-    margin-right: 0.1875rem;
-  }
-`
-
-export const checkboxListCaptionStyles = css`
-  font-size: ${getThemedFontSize(300)};
-  line-height: ${getThemedLineHeight(500)};
-  color: ${getThemedColor('neutral', 700)};
-  text-align: left;
-`
 
 export const checkboxListContentListStyles = (
   horizontal?: boolean,
   isExpanded?: boolean,
 ) => css`
-  margin-top: ${getThemedSpacing(300)};
   display: flex;
   flex-direction: ${horizontal ? 'row' : 'column'};
   flex-wrap: wrap;
@@ -54,23 +19,6 @@ export const checkboxListContentListStyles = (
   transition:
     max-height 250ms ease,
     opacity 200ms ease;
-`
-
-export const checkboxListErrorBarStyles = css`
-  width: 0.1875rem;
-  height: 100%;
-  background-color: ${getThemedColor('error', 900)};
-  position: absolute;
-  top: 0;
-  left: 0;
-`
-
-export const checkboxListErrorMessageStyles = css`
-  font-size: ${getThemedFontSize(300)};
-  line-height: ${getThemedLineHeight(500)};
-  font-weight: 700;
-  color: ${getThemedColor('error', 900)};
-  text-align: left;
 `
 
 export const checkboxCounterTextStyles = css`
@@ -90,4 +38,11 @@ export const expandButtonStyles = css`
   > span {
     margin-left: 0.375rem;
   }
+`
+
+export const checkboxListLabelRowStyles = css`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  width: 100%;
 `

--- a/src/components/Forms/Inputs/Combobox/ComboboxDemo.tsx
+++ b/src/components/Forms/Inputs/Combobox/ComboboxDemo.tsx
@@ -9,53 +9,60 @@ const items = [
 
 const ComboboxDemo = () => (
   <DemoWrapper title='Combobox'>
-    <div style={{ width: '18.125rem', flexDirection: 'column', display: 'flex', gap: '1.25rem' }} >
-    <Combobox
-      initialItems={items}
-      label='Label'
-      caption='Caption'
-      placeholder='placeholder'
-      required
-      showSelectedItems
-    />
-    <Combobox
-      initialItems={items}
-      label='Label'
-      caption='Caption'
-      placeholder='placeholder'
-      size='small'
-    />
-    <Combobox
-      initialItems={items}
-      label='Label'
-      caption='Caption'
-      placeholder='placeholder'
-      showOptionalLabel={false}
-    />
-    <Combobox
-      initialItems={items}
-      label='Multiple'
-      caption='Caption'
-      placeholder='placeholder'
-      multiple
-      required
-      showSelectedItems
-    />
-    <Combobox
-      initialItems={items}
-      label='Label'
-      caption='Caption'
-      placeholder='placeholder'
-      errorMessage='Error Message'
-      required
-    />
-    <Combobox
-      initialItems={items}
-      label='Label'
-      caption='Caption'
-      placeholder='placeholder'
-      required
-      disabled
+    <div
+      style={{
+        width: '18.125rem',
+        flexDirection: 'column',
+        display: 'flex',
+        gap: '1.25rem',
+      }}
+    >
+      <Combobox
+        initialItems={items}
+        label='Label'
+        caption='Caption'
+        placeholder='placeholder'
+        required
+        showSelectedItems
+      />
+      <Combobox
+        initialItems={items}
+        label='Label'
+        caption='Caption'
+        placeholder='placeholder'
+        size='small'
+      />
+      <Combobox
+        initialItems={items}
+        label='Label'
+        caption='Caption'
+        placeholder='placeholder'
+        showOptionalLabel={false}
+      />
+      <Combobox
+        initialItems={items}
+        label='Multiple'
+        caption='Caption'
+        placeholder='placeholder'
+        multiple
+        required
+        showSelectedItems
+      />
+      <Combobox
+        initialItems={items}
+        label='Label'
+        caption='Caption'
+        placeholder='placeholder'
+        errorMessage='Error Message'
+        required
+      />
+      <Combobox
+        initialItems={items}
+        label='Label'
+        caption='Caption'
+        placeholder='placeholder'
+        required
+        disabled
       />
     </div>
   </DemoWrapper>

--- a/src/components/Forms/Inputs/Combobox/ComboboxDemo.tsx
+++ b/src/components/Forms/Inputs/Combobox/ComboboxDemo.tsx
@@ -9,6 +9,7 @@ const items = [
 
 const ComboboxDemo = () => (
   <DemoWrapper title='Combobox'>
+    <div style={{ width: '18.125rem', flexDirection: 'column', display: 'flex', gap: '1.25rem' }} >
     <Combobox
       initialItems={items}
       label='Label'
@@ -55,7 +56,8 @@ const ComboboxDemo = () => (
       placeholder='placeholder'
       required
       disabled
-    />
+      />
+    </div>
   </DemoWrapper>
 )
 

--- a/src/components/Forms/Inputs/Combobox/index.tsx
+++ b/src/components/Forms/Inputs/Combobox/index.tsx
@@ -3,21 +3,14 @@
 
 import { useState } from 'react'
 import {
-  Field,
   Combobox as ChakraCombobox,
   Portal,
   useFilter,
   useListCollection,
 } from '@chakra-ui/react'
 import Tag from '../../Tag'
-import {
-  fieldCaptionStyles,
-  fieldErrorMessageStyles,
-  fieldLabelStyles,
-  textInputContainerStyles,
-  textInputErrorBarStyles,
-  textInputStyles,
-} from '../TextInput/styled'
+import { textInputStyles } from '../TextInput/styled'
+import FieldWrapper from '../FieldWrapper'
 import { useLabels } from '../../../../lib/i18n/useLabels'
 import { ComboboxProps } from './types'
 
@@ -54,83 +47,60 @@ const Combobox = ({
     filter: contains,
   })
 
-  return (
-    <div
-      css={textInputContainerStyles(size, noMarginBottom)}
-      className='ds-text-input-container'
-    >
-      {errorMessage ? <div css={textInputErrorBarStyles} /> : null}
-      <Field.Root
-        required={required}
-        invalid={!!errorMessage}
-        gap='0'
-        style={{ marginLeft: errorMessage ? '1.1875rem' : '0px' }}
-      >
-        {label ? (
-          <Field.Label
-            css={fieldLabelStyles(size, disabled)}
-            aria-label={label}
-          >
-            <Field.RequiredIndicator aria-label={l.requiredSymbolLabel} />
-            {label}
-            {!required && showOptionalLabel ? (
-              <span>{l.optionalSuffix}</span>
-            ) : null}
-          </Field.Label>
-        ) : null}
-        {caption ? (
-          <Field.HelperText
-            css={fieldCaptionStyles(size, disabled)}
-            aria-label={caption}
-          >
-            {caption}
-          </Field.HelperText>
-        ) : null}
-        {errorMessage ? (
-          <Field.ErrorText
-            css={fieldErrorMessageStyles(size)}
-            aria-label={errorMessage}
-          >
-            {errorMessage}
-          </Field.ErrorText>
-        ) : null}
+  const isFilled = selectedItems.length > 0
 
-        <ChakraCombobox.Root
-          multiple={multiple}
-          onValueChange={handleValueChange}
-          value={selectedItems.map((item) => item.value)}
-          collection={collection}
-          onInputValueChange={(e) => filter(e.inputValue)}
-          width='20rem'
-          size={size === 'small' ? 'sm' : 'md'}
-        >
-          <ChakraCombobox.Control>
-            <ChakraCombobox.Input
-              placeholder={placeholder}
-              css={textInputStyles(size)}
-              disabled={disabled}
-              aria-label={label || placeholder || l.defaultInputAriaLabel}
-            />
-            <ChakraCombobox.IndicatorGroup>
-              <ChakraCombobox.ClearTrigger aria-label={l.clearSelectionLabel} />
-              <ChakraCombobox.Trigger aria-label={l.toggleOptionsLabel} />
-            </ChakraCombobox.IndicatorGroup>
-          </ChakraCombobox.Control>
-          <Portal>
-            <ChakraCombobox.Positioner>
-              <ChakraCombobox.Content>
-                <ChakraCombobox.Empty>
-                  {l.noItemsFoundLabel}
-                </ChakraCombobox.Empty>
-                {collection.items.map((item) => (
-                  <ChakraCombobox.Item item={item} key={item.value}>
-                    {item.label}
-                    <ChakraCombobox.ItemIndicator />
-                  </ChakraCombobox.Item>
-                ))}
-              </ChakraCombobox.Content>
-            </ChakraCombobox.Positioner>
-          </Portal>
+  return (
+    <FieldWrapper
+      className='ds-text-input-container'
+      label={label}
+      caption={caption}
+      errorMessage={errorMessage}
+      required={required}
+      disabled={disabled}
+      size={size}
+      showOptionalLabel={showOptionalLabel}
+      noMarginBottom={noMarginBottom}
+      labels={{
+        requiredSymbolLabel: l.requiredSymbolLabel,
+        optionalSuffix: l.optionalSuffix,
+      }}
+      semantics='field'
+    >
+      <ChakraCombobox.Root
+        multiple={multiple}
+        onValueChange={handleValueChange}
+        value={selectedItems.map((item) => item.value)}
+        collection={collection}
+        onInputValueChange={(e) => filter(e.inputValue)}
+        width='20rem'
+        size={size === 'small' ? 'sm' : 'md'}
+      >
+        <ChakraCombobox.Control>
+          <ChakraCombobox.Input
+            placeholder={placeholder}
+            css={textInputStyles(size, isFilled)}
+            disabled={disabled}
+            aria-label={label || placeholder || l.defaultInputAriaLabel}
+          />
+          <ChakraCombobox.IndicatorGroup>
+            <ChakraCombobox.ClearTrigger aria-label={l.clearSelectionLabel} />
+            <ChakraCombobox.Trigger aria-label={l.toggleOptionsLabel} />
+          </ChakraCombobox.IndicatorGroup>
+        </ChakraCombobox.Control>
+        <Portal>
+          <ChakraCombobox.Positioner>
+            <ChakraCombobox.Content>
+              <ChakraCombobox.Empty>{l.noItemsFoundLabel}</ChakraCombobox.Empty>
+              {collection.items.map((item) => (
+                <ChakraCombobox.Item item={item} key={item.value}>
+                  {item.label}
+                  <ChakraCombobox.ItemIndicator />
+                </ChakraCombobox.Item>
+              ))}
+            </ChakraCombobox.Content>
+          </ChakraCombobox.Positioner>
+        </Portal>
+        {showSelectedItems ? (
           <div
             style={{
               display: 'flex',
@@ -140,24 +110,23 @@ const Combobox = ({
               paddingTop: '0.5rem',
             }}
           >
-            {showSelectedItems &&
-              selectedItems.map((item) => (
-                <Tag
-                  key={item.value}
-                  label={item.label}
-                  variant='info-white'
-                  onClose={() =>
-                    setSelectedItems((prev) =>
-                      prev.filter((i) => i.value !== item.value),
-                    )
-                  }
-                  closable
-                />
-              ))}
+            {selectedItems.map((item) => (
+              <Tag
+                key={item.value}
+                label={item.label}
+                variant='info-white'
+                onClose={() =>
+                  setSelectedItems((prev) =>
+                    prev.filter((i) => i.value !== item.value),
+                  )
+                }
+                closable
+              />
+            ))}
           </div>
-        </ChakraCombobox.Root>
-      </Field.Root>
-    </div>
+        ) : null}
+      </ChakraCombobox.Root>
+    </FieldWrapper>
   )
 }
 

--- a/src/components/Forms/Inputs/FieldWrapper/index.tsx
+++ b/src/components/Forms/Inputs/FieldWrapper/index.tsx
@@ -1,0 +1,168 @@
+/** @jsxImportSource @emotion/react */
+/* eslint-disable react/no-unknown-property */
+
+import { Field } from '@chakra-ui/react'
+import {
+  fieldWrapperCaptionStyles,
+  fieldWrapperContainerStyles,
+  fieldWrapperContentStyles,
+  fieldWrapperErrorBarStyles,
+  fieldWrapperErrorMessageStyles,
+  fieldWrapperFooterStyles,
+  fieldWrapperHeaderStyles,
+  fieldWrapperLabelStyles,
+} from './styled'
+import { FieldWrapperProps } from './types'
+
+const DEFAULT_REQUIRED_SYMBOL_LABEL = 'required'
+const DEFAULT_OPTIONAL_SUFFIX = ' (Optional)'
+
+const FieldWrapper = ({
+  label,
+  caption,
+  errorMessage,
+  invalid,
+  required,
+  disabled,
+  size = 'default',
+  showOptionalLabel = true,
+  noMarginBottom = false,
+  labels,
+  footer,
+  semantics = 'field',
+  className,
+  style,
+  children,
+  captionId,
+  errorId,
+  containerProps,
+}: FieldWrapperProps) => {
+  const hasError = !!errorMessage || !!invalid
+  const requiredSymbolLabel =
+    labels?.requiredSymbolLabel ?? DEFAULT_REQUIRED_SYMBOL_LABEL
+  const optionalSuffix = labels?.optionalSuffix ?? DEFAULT_OPTIONAL_SUFFIX
+  const hasHeader = !!(label || caption || errorMessage)
+
+  const renderFieldHeader = () => {
+    if (!hasHeader) return null
+
+    return (
+      <div css={fieldWrapperHeaderStyles}>
+        {label ? (
+          <Field.Label
+            css={fieldWrapperLabelStyles(size, disabled)}
+            aria-label={typeof label === 'string' ? label : undefined}
+          >
+            <Field.RequiredIndicator aria-label={requiredSymbolLabel} />
+            {label}
+            {!required && showOptionalLabel ? (
+              <span>{optionalSuffix}</span>
+            ) : null}
+          </Field.Label>
+        ) : null}
+        {caption ? (
+          <Field.HelperText
+            id={captionId}
+            css={fieldWrapperCaptionStyles(size, disabled)}
+            aria-label={caption}
+          >
+            {caption}
+          </Field.HelperText>
+        ) : null}
+        {errorMessage ? (
+          <Field.ErrorText
+            id={errorId}
+            css={fieldWrapperErrorMessageStyles(size)}
+            aria-label={errorMessage}
+          >
+            {errorMessage}
+          </Field.ErrorText>
+        ) : null}
+      </div>
+    )
+  }
+
+  const renderGroupHeader = () => {
+    if (!hasHeader) return null
+
+    return (
+      <div css={fieldWrapperHeaderStyles}>
+        {label ? (
+          <p
+            css={fieldWrapperLabelStyles(size, disabled)}
+            aria-label={typeof label === 'string' ? label : undefined}
+            data-disabled={disabled || undefined}
+          >
+            {required ? (
+              <span data-required-indicator aria-label={requiredSymbolLabel}>
+                *
+              </span>
+            ) : null}
+            {label}
+          </p>
+        ) : null}
+        {caption ? (
+          <p
+            id={captionId}
+            css={fieldWrapperCaptionStyles(size, disabled)}
+            aria-label={caption}
+          >
+            {caption}
+          </p>
+        ) : null}
+        {errorMessage ? (
+          <p
+            id={errorId}
+            css={fieldWrapperErrorMessageStyles(size)}
+            aria-label={errorMessage}
+          >
+            {errorMessage}
+          </p>
+        ) : null}
+      </div>
+    )
+  }
+
+  const content = (
+    <div css={fieldWrapperContentStyles}>
+      {semantics === 'field' ? renderFieldHeader() : renderGroupHeader()}
+      {children}
+      {footer ? <div css={fieldWrapperFooterStyles}>{footer}</div> : null}
+    </div>
+  )
+
+  return (
+    <div
+      css={fieldWrapperContainerStyles(noMarginBottom, hasError)}
+      className={className}
+      style={style}
+      {...containerProps}
+    >
+      {hasError ? <div css={fieldWrapperErrorBarStyles} /> : null}
+      {semantics === 'field' ? (
+        <Field.Root
+          required={required}
+          invalid={hasError}
+          gap='0'
+          width='100%'
+          flex='1'
+          minW='0'
+        >
+          {content}
+        </Field.Root>
+      ) : (
+        content
+      )}
+    </div>
+  )
+}
+
+export default FieldWrapper
+export type { FieldWrapperProps, FieldWrapperLabels, FieldWrapperSize } from './types'
+export {
+  fieldFocusVisibleStyleObject,
+  fieldFocusVisibleStyles,
+  fieldWrapperCaptionStyles,
+  fieldWrapperErrorMessageStyles,
+  fieldWrapperLabelStyles,
+} from './styled'

--- a/src/components/Forms/Inputs/FieldWrapper/index.tsx
+++ b/src/components/Forms/Inputs/FieldWrapper/index.tsx
@@ -158,7 +158,11 @@ const FieldWrapper = ({
 }
 
 export default FieldWrapper
-export type { FieldWrapperProps, FieldWrapperLabels, FieldWrapperSize } from './types'
+export type {
+  FieldWrapperProps,
+  FieldWrapperLabels,
+  FieldWrapperSize,
+} from './types'
 export {
   fieldFocusVisibleStyleObject,
   fieldFocusVisibleStyles,

--- a/src/components/Forms/Inputs/FieldWrapper/styled.ts
+++ b/src/components/Forms/Inputs/FieldWrapper/styled.ts
@@ -93,15 +93,15 @@ export const fieldWrapperLabelStyles = (
   .chakra-field__requiredIndicator {
     margin-top: ${getThemedSpacing(100)};
     color: ${disabled
-    ? getThemedColor('neutral', 600)
-    : getThemedColor('error', 500)};
+      ? getThemedColor('neutral', 600)
+      : getThemedColor('error', 500)};
   }
 
   /* Group-semantics required asterisk */
   > span[data-required-indicator] {
     color: ${disabled
-    ? getThemedColor('neutral', 600)
-    : getThemedColor('error', 500)};
+      ? getThemedColor('neutral', 600)
+      : getThemedColor('error', 500)};
     margin-right: 0.1875rem;
   }
 

--- a/src/components/Forms/Inputs/FieldWrapper/styled.ts
+++ b/src/components/Forms/Inputs/FieldWrapper/styled.ts
@@ -1,0 +1,158 @@
+import { css } from '@emotion/react'
+import {
+  getThemedBorderWidth,
+  getThemedColor,
+  getThemedFontSize,
+  getThemedLineHeight,
+  getThemedSpacing,
+} from '../../../../lib/theme'
+import { FieldWrapperSize } from './types'
+
+/** Shared keyboard-only focus ring values (usable with Chakra SystemStyleObject). */
+export const fieldFocusVisibleStyleObject = {
+  outline: `${getThemedBorderWidth(200)} solid ${getThemedColor('primary', 700)}`,
+  outlineOffset: getThemedSpacing(50),
+  boxShadow: `0 0 0 0.125rem ${getThemedColor('neutral', 100)}, rgba(0, 0, 0, 0.05) 0 0.125rem 0.125rem 0.25rem`,
+} as const
+
+/** Shared keyboard-only focus ring for form controls (Emotion). */
+export const fieldFocusVisibleStyles = css`
+  outline: ${fieldFocusVisibleStyleObject.outline};
+  outline-offset: ${fieldFocusVisibleStyleObject.outlineOffset};
+  box-shadow: ${fieldFocusVisibleStyleObject.boxShadow};
+`
+
+export const fieldWrapperContainerStyles = (
+  noMarginBottom?: boolean,
+  hasError?: boolean,
+) => css`
+  position: relative;
+  height: 100%;
+  width: 100%;
+  display: flex;
+  flex-direction: row;
+  align-items: stretch;
+  gap: ${hasError ? '1rem' : '0'};
+
+  &:focus-visible {
+    ${fieldFocusVisibleStyles}
+  }
+`
+
+export const fieldWrapperErrorBarStyles = css`
+  width: 0.1875rem;
+  flex-shrink: 0;
+  align-self: stretch;
+  background-color: ${getThemedColor('error', 900)};
+`
+
+export const fieldWrapperContentStyles = css`
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+  gap: ${getThemedSpacing(200)};
+  width: 100%;
+  flex: 1;
+  min-width: 0;
+`
+
+export const fieldWrapperHeaderStyles = css`
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+  gap: ${getThemedSpacing(50)};
+  width: 100%;
+`
+
+export const fieldWrapperLabelStyles = (
+  size: FieldWrapperSize = 'default',
+  disabled?: boolean,
+) => css`
+  color: ${getThemedColor('neutral', disabled ? 600 : 900)};
+  font-size: ${size === 'small'
+    ? getThemedFontSize(300)
+    : getThemedFontSize(400)};
+  font-weight: 400;
+  line-height: ${size === 'small'
+    ? getThemedLineHeight(500)
+    : getThemedLineHeight(600)};
+  display: flex;
+  align-items: flex-start;
+  text-align: left;
+  -webkit-user-select: text;
+  -moz-user-select: text;
+  -ms-user-select: text;
+  user-select: text;
+  cursor: text;
+  margin: 0;
+
+  span {
+    color: ${getThemedColor('neutral', disabled ? 600 : 700)};
+  }
+
+  .chakra-field__requiredIndicator {
+    margin-top: ${getThemedSpacing(100)};
+    color: ${disabled
+    ? getThemedColor('neutral', 600)
+    : getThemedColor('error', 500)};
+  }
+
+  /* Group-semantics required asterisk */
+  > span[data-required-indicator] {
+    color: ${disabled
+    ? getThemedColor('neutral', 600)
+    : getThemedColor('error', 500)};
+    margin-right: 0.1875rem;
+  }
+
+  &[data-disabled] {
+    color: ${getThemedColor('neutral', 600)};
+
+    span {
+      color: ${getThemedColor('neutral', 600)};
+    }
+  }
+`
+
+export const fieldWrapperCaptionStyles = (
+  size: FieldWrapperSize = 'default',
+  disabled?: boolean,
+) => css`
+  color: ${getThemedColor('neutral', disabled ? 600 : 700)};
+  font-size: ${size === 'small'
+    ? getThemedFontSize(200)
+    : getThemedFontSize(300)};
+  font-weight: 400;
+  line-height: ${size === 'small'
+    ? getThemedLineHeight(400)
+    : getThemedLineHeight(500)};
+  text-align: left;
+  margin: 0;
+
+  &:first-letter {
+    text-transform: uppercase;
+  }
+`
+
+export const fieldWrapperErrorMessageStyles = (
+  size: FieldWrapperSize = 'default',
+) => css`
+  color: ${getThemedColor('error', 900)};
+  font-size: ${size === 'small'
+    ? getThemedFontSize(200)
+    : getThemedFontSize(300)};
+  font-weight: 700;
+  line-height: ${size === 'small'
+    ? getThemedLineHeight(400)
+    : getThemedLineHeight(500)};
+  text-align: left;
+  margin: 0;
+`
+
+export const fieldWrapperFooterStyles = css`
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+  gap: ${getThemedSpacing(50)};
+  width: 100%;
+`

--- a/src/components/Forms/Inputs/FieldWrapper/types.ts
+++ b/src/components/Forms/Inputs/FieldWrapper/types.ts
@@ -1,0 +1,47 @@
+import type { ReactNode, CSSProperties, HTMLAttributes } from 'react'
+
+export type FieldWrapperSize = 'small' | 'default'
+
+export type FieldWrapperLabels = {
+  /** Accessible label for the required (*) indicator. Default: "required" */
+  requiredSymbolLabel?: string
+  /**
+   * Suffix appended after the field label when the field is optional.
+   * Default: " (Optional)"
+   */
+  optionalSuffix?: ReactNode
+}
+
+export type FieldWrapperProps = {
+  label?: ReactNode
+  caption?: string
+  errorMessage?: string
+  /**
+   * Forces the error-bar / invalid state even when `errorMessage` is empty
+   * (e.g. Textarea min/max validation shown in the footer).
+   */
+  invalid?: boolean
+  required?: boolean
+  disabled?: boolean
+  size?: FieldWrapperSize
+  showOptionalLabel?: boolean
+  noMarginBottom?: boolean
+  /** Override strings used by field-semantics labels. */
+  labels?: FieldWrapperLabels
+  /** Optional slot rendered after the control (e.g. Textarea char-count / min-max errors). */
+  footer?: ReactNode
+  /**
+   * `field` — Chakra Field primitives (TextInput, Textarea, Combobox).
+   * `group` — plain markup for composite / list inputs (Select, RadioList, etc.).
+   */
+  semantics?: 'field' | 'group'
+  className?: string
+  style?: CSSProperties
+  children: ReactNode
+  /** Optional id on the caption element (for aria-describedby). */
+  captionId?: string
+  /** Optional id on the error element (for aria-describedby). */
+  errorId?: string
+  /** Extra props applied to the outer container element. */
+  containerProps?: HTMLAttributes<HTMLDivElement>
+}

--- a/src/components/Forms/Inputs/InputWithUnits/index.tsx
+++ b/src/components/Forms/Inputs/InputWithUnits/index.tsx
@@ -6,15 +6,12 @@ import { Group } from '@chakra-ui/react'
 
 import { InputWithUnitsProps } from './types'
 import {
-  errorBarStyles,
-  inputWithUnitsCaptionStyles,
   inputWithUnitsContainerStyles,
-  inputWithUnitsErrorMessageStyles,
-  inputWithUnitsLabelStyles,
   inputWithUnitsStyles,
 } from './styled'
 import TextInput from '../TextInput'
 import Select from '../Select'
+import FieldWrapper from '../FieldWrapper'
 
 const InputWithUnits = ({
   label,
@@ -44,20 +41,16 @@ const InputWithUnits = ({
 
   return (
     <div css={inputWithUnitsStyles}>
-      {errorMessage ? <div css={errorBarStyles} /> : null}
-      <div style={{ marginLeft: errorMessage ? '1.1875rem' : '0px' }}>
-        <p css={inputWithUnitsLabelStyles(disabled)} aria-label={label}>
-          {required ? <span>*</span> : null}
-          {label}
-        </p>
-        <p css={inputWithUnitsCaptionStyles(disabled)} aria-label={caption}>
-          {caption}
-        </p>
-        {errorMessage ? (
-          <p css={inputWithUnitsErrorMessageStyles} aria-label={errorMessage}>
-            {errorMessage}
-          </p>
-        ) : null}
+      <FieldWrapper
+        label={label}
+        caption={caption}
+        errorMessage={errorMessage}
+        required={required}
+        disabled={disabled}
+        showOptionalLabel={false}
+        noMarginBottom
+        semantics='group'
+      >
         <Group
           css={inputWithUnitsContainerStyles(!!errorMessage, unitsPosition)}
           attached
@@ -80,6 +73,7 @@ const InputWithUnits = ({
             aria-label={`${label} value`}
             value={inputValue}
             disabled={disabled}
+            noMarginBottom
             onChange={(e) => {
               setInputValue(e.target.value)
               handleOnChange(e.target.value)
@@ -99,7 +93,7 @@ const InputWithUnits = ({
             />
           ) : null}
         </Group>
-      </div>
+      </FieldWrapper>
     </div>
   )
 }

--- a/src/components/Forms/Inputs/InputWithUnits/index.tsx
+++ b/src/components/Forms/Inputs/InputWithUnits/index.tsx
@@ -5,10 +5,7 @@ import { useState } from 'react'
 import { Group } from '@chakra-ui/react'
 
 import { InputWithUnitsProps } from './types'
-import {
-  inputWithUnitsContainerStyles,
-  inputWithUnitsStyles,
-} from './styled'
+import { inputWithUnitsContainerStyles, inputWithUnitsStyles } from './styled'
 import TextInput from '../TextInput'
 import Select from '../Select'
 import FieldWrapper from '../FieldWrapper'

--- a/src/components/Forms/Inputs/InputWithUnits/styled.ts
+++ b/src/components/Forms/Inputs/InputWithUnits/styled.ts
@@ -2,8 +2,6 @@ import { css } from '@emotion/react'
 import {
   getThemedBorderWidth,
   getThemedColor,
-  getThemedFontSize,
-  getThemedLineHeight,
   getThemedSpacing,
 } from '../../../../lib/theme'
 import { InputWithUnitsProps } from './types'
@@ -14,56 +12,11 @@ export const inputWithUnitsStyles = css`
   position: relative;
 `
 
-export const inputWithUnitsLabelStyles = (
-  disabled?: InputWithUnitsProps['disabled'],
-) => css`
-  font-size: ${getThemedFontSize(400)};
-  line-height: ${getThemedLineHeight(600)};
-  font-weight: 400;
-  color: ${getThemedColor('neutral', disabled ? 600 : 900)};
-  text-align: left;
-
-  span {
-    color: ${disabled
-      ? getThemedColor('neutral', 600)
-      : getThemedColor('error', 500)};
-    margin-right: 0.1875rem;
-  }
-`
-
-export const inputWithUnitsCaptionStyles = (
-  disabled?: InputWithUnitsProps['disabled'],
-) => css`
-  font-size: ${getThemedFontSize(300)};
-  line-height: ${getThemedLineHeight(500)};
-  font-weight: 400;
-  color: ${getThemedColor('neutral', disabled ? 600 : 700)};
-  text-align: left;
-`
-
-export const errorBarStyles = css`
-  width: 0.1875rem;
-  height: 100%;
-  background-color: ${getThemedColor('error', 900)};
-  position: absolute;
-  top: 0;
-  left: 0;
-`
-
-export const inputWithUnitsErrorMessageStyles = css`
-  font-size: ${getThemedFontSize(300)};
-  line-height: ${getThemedLineHeight(500)};
-  font-weight: 700;
-  color: ${getThemedColor('error', 900)};
-  text-align: left;
-`
-
 export const inputWithUnitsContainerStyles = (
   hasError: boolean,
   unitsPosition?: InputWithUnitsProps['unitsPosition'],
 ) => css`
   width: 100%;
-  margin-top: ${getThemedSpacing(200)};
 
   .ds-text-input-container {
     margin-bottom: 0;

--- a/src/components/Forms/Inputs/Password/index.tsx
+++ b/src/components/Forms/Inputs/Password/index.tsx
@@ -6,13 +6,12 @@ import type { ReactNode } from 'react'
 
 import TextInput from '../TextInput'
 import Button from '../../Actions/Button'
+import FieldWrapper from '../FieldWrapper'
 import { PasswordProps, StrengthLevel } from './types'
 import { useLabels } from '../../../../lib/i18n/useLabels'
 import {
-  passwordCaptionStyles,
   passwordContainerStyles,
   passwordContentStyles,
-  passwordLabelStyles,
   passwordStrengthBarStyles,
   passwordStrengthContainerStyles,
   passwordStrengthItemStyles,
@@ -105,178 +104,185 @@ const Password = ({
 
   return (
     <div css={passwordContainerStyles}>
-      <p css={passwordLabelStyles} aria-label={label}>
-        {required ? <span>*</span> : null}
-        {label}
-      </p>
-      <p css={passwordCaptionStyles} aria-label={caption}>
-        {caption}
-      </p>
-      <div css={passwordContentStyles}>
-        <TextInput
-          type={show ? 'text' : 'password'}
-          aria-label={label}
-          value={password}
-          aria-describedby='password-guidelines'
-          onChange={(e) => validatePassword(e.target.value)}
-        />
-        <Button
-          label={show ? l.hideLabel : l.showLabel}
-          variant='secondary'
-          leftIcon={show ? <HideIcon /> : <ShowIcon />}
-          aria-label={show ? l.hidePasswordLabel : l.showPasswordLabel}
-          onClick={() => setShow(!show)}
-          type='button'
-        />
-      </div>
-      {password && !hideValidations ? (
-        <div
-          id='password-guidelines'
-          css={passwordStrengthContainerStyles}
-          aria-live='polite'
-        >
-          <p
-            css={passwordStrengthLabelStyles(passwordStatus.strength)}
-            aria-live='polite'
-            role='status'
-          >
-            {l.strengthPrefix}{' '}
-            <span>{strengthDisplay[passwordStatus.strength]}</span>
-          </p>
-          <div css={passwordStrengthBarStyles(passwordStatus.strength)}>
-            <div />
-          </div>
-          <div
-            css={passwordStrengthItemStyles(passwordStatus.length)}
-            aria-label={`${l.minLengthRule(minLength)}. ${
-              passwordStatus.length ? l.requirementMet : l.requirementNotMet
-            }`}
-          >
-            <div>
-              {passwordStatus.length ? (
-                <CheckIcon
-                  color='var(--chakra-colors-success-500)'
-                  height='0.5rem'
-                  width='0.5rem'
-                />
-              ) : (
-                <CloseIcon
-                  color='var(--chakra-colors-error-900)'
-                  height='0.5rem'
-                  width='0.5rem'
-                />
-              )}
-            </div>
-            <p>{l.minLengthRule(minLength)}</p>
-          </div>
-          {!disabledRules?.uppercase ? (
-            <div
-              css={passwordStrengthItemStyles(passwordStatus.uppercase)}
-              aria-label={`${l.uppercaseRule}. ${
-                passwordStatus.uppercase
-                  ? l.requirementMet
-                  : l.requirementNotMet
-              }`}
-            >
-              <div>
-                {passwordStatus.uppercase ? (
-                  <CheckIcon
-                    color='var(--chakra-colors-success-500)'
-                    height='0.5rem'
-                    width='0.5rem'
-                  />
-                ) : (
-                  <CloseIcon
-                    color='var(--chakra-colors-error-900)'
-                    height='0.5rem'
-                    width='0.5rem'
-                  />
-                )}
-              </div>
-              <p>{l.uppercaseRule}</p>
-            </div>
-          ) : null}
-          {!disabledRules?.lowercase ? (
-            <div
-              css={passwordStrengthItemStyles(passwordStatus.lowercase)}
-              aria-label={`${l.lowercaseRule}. ${
-                passwordStatus.lowercase
-                  ? l.requirementMet
-                  : l.requirementNotMet
-              }`}
-            >
-              <div>
-                {passwordStatus.lowercase ? (
-                  <CheckIcon
-                    color='var(--chakra-colors-success-500)'
-                    height='0.5rem'
-                    width='0.5rem'
-                  />
-                ) : (
-                  <CloseIcon
-                    color='var(--chakra-colors-error-900)'
-                    height='0.5rem'
-                    width='0.5rem'
-                  />
-                )}
-              </div>
-              <p>{l.lowercaseRule}</p>
-            </div>
-          ) : null}
-          {!disabledRules?.numbers ? (
-            <div
-              css={passwordStrengthItemStyles(passwordStatus.numbers)}
-              aria-label={`${l.numberRule}. ${
-                passwordStatus.numbers ? l.requirementMet : l.requirementNotMet
-              }`}
-            >
-              <div>
-                {passwordStatus.numbers ? (
-                  <CheckIcon
-                    color='var(--chakra-colors-success-500)'
-                    height='0.5rem'
-                    width='0.5rem'
-                  />
-                ) : (
-                  <CloseIcon
-                    color='var(--chakra-colors-error-900)'
-                    height='0.5rem'
-                    width='0.5rem'
-                  />
-                )}
-              </div>
-              <p>{l.numberRule}</p>
-            </div>
-          ) : null}
-          {!disabledRules?.specialCharacters ? (
-            <div
-              css={passwordStrengthItemStyles(passwordStatus.specialCharacters)}
-              aria-label={`${l.specialCharRule}. ${
-                passwordStatus.specialCharacters
-                  ? l.requirementMet
-                  : l.requirementNotMet
-              }`}
-            >
-              <div>
-                {passwordStatus.specialCharacters ? (
-                  <CheckIcon
-                    color='var(--chakra-colors-success-500)'
-                    height='0.5rem'
-                    width='0.5rem'
-                  />
-                ) : (
-                  <CloseIcon
-                    color='var(--chakra-colors-error-900)'
-                    height='0.5rem'
-                    width='0.5rem'
-                  />
-                )}
-              </div>
-              <p>{l.specialCharRule}</p>
-            </div>
-          ) : null}
+      <FieldWrapper
+        label={label}
+        caption={caption}
+        required={required}
+        showOptionalLabel={false}
+        noMarginBottom
+        semantics='group'
+      >
+        <div css={passwordContentStyles}>
+          <TextInput
+            type={show ? 'text' : 'password'}
+            aria-label={label}
+            value={password}
+            aria-describedby='password-guidelines'
+            onChange={(e) => validatePassword(e.target.value)}
+            noMarginBottom
+          />
+          <Button
+            label={show ? l.hideLabel : l.showLabel}
+            variant='secondary'
+            leftIcon={show ? <HideIcon /> : <ShowIcon />}
+            aria-label={show ? l.hidePasswordLabel : l.showPasswordLabel}
+            onClick={() => setShow(!show)}
+            type='button'
+          />
         </div>
-      ) : null}
+        {password && !hideValidations ? (
+          <div
+            id='password-guidelines'
+            css={passwordStrengthContainerStyles}
+            aria-live='polite'
+          >
+            <p
+              css={passwordStrengthLabelStyles(passwordStatus.strength)}
+              aria-live='polite'
+              role='status'
+            >
+              {l.strengthPrefix}{' '}
+              <span>{strengthDisplay[passwordStatus.strength]}</span>
+            </p>
+            <div css={passwordStrengthBarStyles(passwordStatus.strength)}>
+              <div />
+            </div>
+            <div
+              css={passwordStrengthItemStyles(passwordStatus.length)}
+              aria-label={`${l.minLengthRule(minLength)}. ${
+                passwordStatus.length ? l.requirementMet : l.requirementNotMet
+              }`}
+            >
+              <div>
+                {passwordStatus.length ? (
+                  <CheckIcon
+                    color='var(--chakra-colors-success-500)'
+                    height='0.5rem'
+                    width='0.5rem'
+                  />
+                ) : (
+                  <CloseIcon
+                    color='var(--chakra-colors-error-900)'
+                    height='0.5rem'
+                    width='0.5rem'
+                  />
+                )}
+              </div>
+              <p>{l.minLengthRule(minLength)}</p>
+            </div>
+            {!disabledRules?.uppercase ? (
+              <div
+                css={passwordStrengthItemStyles(passwordStatus.uppercase)}
+                aria-label={`${l.uppercaseRule}. ${
+                  passwordStatus.uppercase
+                    ? l.requirementMet
+                    : l.requirementNotMet
+                }`}
+              >
+                <div>
+                  {passwordStatus.uppercase ? (
+                    <CheckIcon
+                      color='var(--chakra-colors-success-500)'
+                      height='0.5rem'
+                      width='0.5rem'
+                    />
+                  ) : (
+                    <CloseIcon
+                      color='var(--chakra-colors-error-900)'
+                      height='0.5rem'
+                      width='0.5rem'
+                    />
+                  )}
+                </div>
+                <p>{l.uppercaseRule}</p>
+              </div>
+            ) : null}
+            {!disabledRules?.lowercase ? (
+              <div
+                css={passwordStrengthItemStyles(passwordStatus.lowercase)}
+                aria-label={`${l.lowercaseRule}. ${
+                  passwordStatus.lowercase
+                    ? l.requirementMet
+                    : l.requirementNotMet
+                }`}
+              >
+                <div>
+                  {passwordStatus.lowercase ? (
+                    <CheckIcon
+                      color='var(--chakra-colors-success-500)'
+                      height='0.5rem'
+                      width='0.5rem'
+                    />
+                  ) : (
+                    <CloseIcon
+                      color='var(--chakra-colors-error-900)'
+                      height='0.5rem'
+                      width='0.5rem'
+                    />
+                  )}
+                </div>
+                <p>{l.lowercaseRule}</p>
+              </div>
+            ) : null}
+            {!disabledRules?.numbers ? (
+              <div
+                css={passwordStrengthItemStyles(passwordStatus.numbers)}
+                aria-label={`${l.numberRule}. ${
+                  passwordStatus.numbers
+                    ? l.requirementMet
+                    : l.requirementNotMet
+                }`}
+              >
+                <div>
+                  {passwordStatus.numbers ? (
+                    <CheckIcon
+                      color='var(--chakra-colors-success-500)'
+                      height='0.5rem'
+                      width='0.5rem'
+                    />
+                  ) : (
+                    <CloseIcon
+                      color='var(--chakra-colors-error-900)'
+                      height='0.5rem'
+                      width='0.5rem'
+                    />
+                  )}
+                </div>
+                <p>{l.numberRule}</p>
+              </div>
+            ) : null}
+            {!disabledRules?.specialCharacters ? (
+              <div
+                css={passwordStrengthItemStyles(
+                  passwordStatus.specialCharacters,
+                )}
+                aria-label={`${l.specialCharRule}. ${
+                  passwordStatus.specialCharacters
+                    ? l.requirementMet
+                    : l.requirementNotMet
+                }`}
+              >
+                <div>
+                  {passwordStatus.specialCharacters ? (
+                    <CheckIcon
+                      color='var(--chakra-colors-success-500)'
+                      height='0.5rem'
+                      width='0.5rem'
+                    />
+                  ) : (
+                    <CloseIcon
+                      color='var(--chakra-colors-error-900)'
+                      height='0.5rem'
+                      width='0.5rem'
+                    />
+                  )}
+                </div>
+                <p>{l.specialCharRule}</p>
+              </div>
+            ) : null}
+          </div>
+        ) : null}
+      </FieldWrapper>
     </div>
   )
 }

--- a/src/components/Forms/Inputs/Password/styled.ts
+++ b/src/components/Forms/Inputs/Password/styled.ts
@@ -13,33 +13,11 @@ export const passwordContainerStyles = css`
   max-width: 30.375rem;
 `
 
-export const passwordLabelStyles = css`
-  font-size: ${getThemedFontSize(400)};
-  line-height: ${getThemedLineHeight(600)};
-  font-weight: 400;
-  color: ${getThemedColor('neutral', 900)};
-  text-align: left;
-
-  span {
-    color: ${getThemedColor('error', 500)};
-    margin-right: 0.1875rem;
-  }
-`
-
-export const passwordCaptionStyles = css`
-  font-size: ${getThemedFontSize(300)};
-  line-height: ${getThemedLineHeight(500)};
-  font-weight: 400;
-  color: ${getThemedColor('neutral', 700)};
-  text-align: left;
-`
-
 export const passwordContentStyles = css`
   display: flex;
   align-items: center;
   justify-content: space-between;
   gap: ${getThemedSpacing(200)};
-  margin-top: ${getThemedSpacing(200)};
 
   .ds-text-input-container {
     margin-bottom: 0;
@@ -55,7 +33,9 @@ export const passwordContentStyles = css`
 `
 
 export const passwordStrengthContainerStyles = css`
-  margin-top: ${getThemedSpacing(300)};
+  display: flex;
+  flex-direction: column;
+  gap: ${getThemedSpacing(200)};
 `
 
 export const passwordStrengthLabelStyles = (strength: string) => css`
@@ -64,6 +44,7 @@ export const passwordStrengthLabelStyles = (strength: string) => css`
   font-weight: 400;
   color: ${getThemedColor('neutral', 800)};
   text-align: left;
+  margin: 0;
 
   span {
     font-weight: 700;
@@ -82,8 +63,7 @@ export const passwordStrengthBarStyles = (strength: string) => css`
   height: ${getThemedSpacing(200)};
   width: 100%;
   background-color: ${getThemedColor('neutral', 300)};
-  margin-top: ${getThemedSpacing(200)};
-  margin-bottom: ${getThemedSpacing(300)};
+  margin-bottom: ${getThemedSpacing(100)};
   border-radius: ${getThemedRadius(500)};
 
   div {
@@ -125,5 +105,9 @@ export const passwordStrengthItemStyles = (isValid: boolean) => css`
     display: flex;
     justify-content: center;
     align-items: center;
+  }
+
+  p {
+    margin: 0;
   }
 `

--- a/src/components/Forms/Inputs/RadioList/index.tsx
+++ b/src/components/Forms/Inputs/RadioList/index.tsx
@@ -1,21 +1,12 @@
 /** @jsxImportSource @emotion/react */
 /* eslint-disable react/no-unknown-property */
 
-import { Group } from '@chakra-ui/react'
 import { RadioListProps } from './types'
 import Radio from '../../Controls/Radio'
-import {
-  radioListCaptionStyles,
-  radioListContainerStyles,
-  radioListContentListStyles,
-  radioListContentStyles,
-  radioListErrorBarStyles,
-  radioListErrorMessageStyles,
-  radioListItemStyles,
-  radioListLabelStyles,
-} from './styled'
+import { radioListItemStyles } from './styled'
 import RadioGroup from '../../Controls/Radio/RadioGroup'
 import { useLabels } from '../../../../lib/i18n/useLabels'
+import FieldWrapper from '../FieldWrapper'
 
 const RadioList = ({
   label,
@@ -35,44 +26,39 @@ const RadioList = ({
   const requiredText = required ? l.requiredLabel : l.optionalLabel
   const errorText = errorMessage ? `${l.errorPrefix} ${errorMessage}.` : ''
   const groupLabel = `${label}. ${captionText} ${requiredText} ${errorText} `
+
   return (
-    <Group
-      css={radioListContainerStyles}
-      aria-roledescription='group'
-      aria-label={groupLabel}
+    <FieldWrapper
+      label={label}
+      caption={caption}
+      errorMessage={errorMessage}
+      required={required}
+      showOptionalLabel={false}
+      noMarginBottom
+      semantics='group'
+      labels={{
+        requiredSymbolLabel: l.requiredSymbolLabel,
+      }}
+      containerProps={{
+        'aria-roledescription': 'group',
+        'aria-label': groupLabel,
+      }}
     >
-      {errorMessage ? <div css={radioListErrorBarStyles} /> : null}
-      <div css={radioListContentStyles(!!errorMessage)}>
-        <p css={radioListLabelStyles} aria-label={label}>
-          {required && <span aria-label={l.requiredSymbolLabel}>*</span>}
-          {label}
-        </p>
-        <p css={radioListCaptionStyles} aria-label={caption}>
-          {caption}
-        </p>
-        {errorMessage ? (
-          <p css={radioListErrorMessageStyles} aria-label={errorMessage}>
-            {errorMessage}
-          </p>
-        ) : null}
-        <div css={radioListContentListStyles}>
-          <RadioGroup
-            name={name}
-            value={defaultValue}
-            onChange={onCheckedChange}
-            horizontal={horizontal && variant !== 'card'}
-          >
-            {radios.map((radio) => (
-              <Radio
-                key={radio.value}
-                css={variant === 'card' ? radioListItemStyles : {}}
-                {...radio}
-              />
-            ))}
-          </RadioGroup>
-        </div>
-      </div>
-    </Group>
+      <RadioGroup
+        name={name}
+        value={defaultValue}
+        onChange={onCheckedChange}
+        horizontal={horizontal && variant !== 'card'}
+      >
+        {radios.map((radio) => (
+          <Radio
+            key={radio.value}
+            css={variant === 'card' ? radioListItemStyles : {}}
+            {...radio}
+          />
+        ))}
+      </RadioGroup>
+    </FieldWrapper>
   )
 }
 

--- a/src/components/Forms/Inputs/RadioList/styled.ts
+++ b/src/components/Forms/Inputs/RadioList/styled.ts
@@ -2,63 +2,9 @@ import { css } from '@emotion/react'
 import {
   getThemedBorderWidth,
   getThemedColor,
-  getThemedFontSize,
-  getThemedLineHeight,
   getThemedRadius,
   getThemedSpacing,
 } from '../../../../lib/theme'
-
-export const radioListContainerStyles = css`
-  position: relative;
-  height: 100%;
-  &:focus-visible {
-    outline-color: ${getThemedColor('primary', 700)};
-  }
-`
-
-export const radioListContentStyles = (hasErrorMessage: boolean) => css`
-  margin-left: ${hasErrorMessage ? '1.1875rem' : '0'};
-`
-
-export const radioListLabelStyles = css`
-  font-size: ${getThemedFontSize(400)};
-  line-height: ${getThemedLineHeight(600)};
-  color: ${getThemedColor('neutral', 900)};
-  text-align: left;
-
-  span {
-    color: ${getThemedColor('error', 500)};
-    margin-right: 0.1875rem;
-  }
-`
-
-export const radioListCaptionStyles = css`
-  font-size: ${getThemedFontSize(300)};
-  line-height: ${getThemedLineHeight(500)};
-  color: ${getThemedColor('neutral', 700)};
-  text-align: left;
-`
-
-export const radioListContentListStyles = css`
-  margin-top: ${getThemedSpacing(300)};
-`
-
-export const radioListErrorBarStyles = css`
-  width: 0.1875rem;
-  height: 100%;
-  background-color: ${getThemedColor('error', 900)};
-  position: absolute;
-  top: 0;
-  left: 0;
-`
-
-export const radioListErrorMessageStyles = css`
-  font-size: ${getThemedFontSize(300)};
-  line-height: ${getThemedLineHeight(500)};
-  font-weight: 700;
-  color: ${getThemedColor('error', 900)};
-  text-align: left;
-`
 
 export const radioListItemStyles = css`
   height: 100%;

--- a/src/components/Forms/Inputs/RichTextEditor/styled.ts
+++ b/src/components/Forms/Inputs/RichTextEditor/styled.ts
@@ -7,6 +7,7 @@ import {
   getThemedRadius,
   getThemedSpacing,
 } from '../../../../lib/theme'
+import { fieldFocusVisibleStyleObject } from '../FieldWrapper/styled'
 
 export const richTextEditorContainerStyles: SystemStyleObject = {
   display: 'flex',
@@ -70,7 +71,7 @@ export const richTextEditorContainerStyles: SystemStyleObject = {
       marginBlock: getThemedSpacing(400),
     },
     '&:focus-visible': {
-      boxShadow: `inset 0 0 0 ${getThemedBorderWidth(200)} ${getThemedColor('primary', 600)}`,
+      ...fieldFocusVisibleStyleObject,
       borderRadius: getThemedRadius(100),
     },
     '& p.is-editor-empty:first-of-type::before': {

--- a/src/components/Forms/Inputs/Select/index.tsx
+++ b/src/components/Forms/Inputs/Select/index.tsx
@@ -8,32 +8,26 @@ import {
   createListCollection,
   HStack,
   SelectValueChangeDetails,
-  Group,
 } from '@chakra-ui/react'
 import {
   SelectContent,
   SelectItem,
-  SelectLabel,
   SelectRoot,
   SelectTrigger,
   SelectValueText,
 } from './BaseSelect'
 import {
-  selectCaptionStyles,
-  selectContainerStyles,
   selectContentStyles,
-  selectErrorBarStyles,
-  selectErrorMessageStyles,
   selectItemCaptionStyles,
   selectItemLabelStyles,
   selectItemStyles,
-  selectLabelStyles,
   selectTriggerStyles,
 } from './styled'
 import { SelectItemProps, SelectProps } from './types'
 import Tag from '../../Tag'
 import Checkbox from '../../Controls/Checkbox'
 import { useLabels } from '../../../../lib/i18n/useLabels'
+import FieldWrapper from '../FieldWrapper'
 
 const getCollectionItems = (items: SelectItemProps[]) =>
   createListCollection({ items })
@@ -101,16 +95,23 @@ const Select = ({
   errorMessage,
   multiple,
   labels,
+  value: controlledValue,
+  defaultValue,
+  style,
   ...rest
 }: SelectProps) => {
   const l = useLabels('Select', labels)
-  const [selectedItems, setSelectedItems] = useState<string[]>(
-    rest.defaultValue || [],
+  const [uncontrolledValue, setUncontrolledValue] = useState<string[]>(
+    defaultValue || [],
   )
+  const isControlled = controlledValue !== undefined
+  const selectedItems = isControlled ? controlledValue : uncontrolledValue
   const selectItems = getCollectionItems(items)
 
   const onChangeHandler = (value: string[]) => {
-    setSelectedItems(value)
+    if (!isControlled) {
+      setUncontrolledValue(value)
+    }
 
     if (onChange) {
       onChange(value)
@@ -121,20 +122,32 @@ const Select = ({
     const newItems = selectedItems.filter((item) => item !== value)
     onChangeHandler(newItems)
   }
+
   const totalAriaLabel =
     `${label || l.defaultAriaLabel}${required ? l.requiredSuffix : ''}${
       caption ? ` ${caption}.` : ''
     }${disabled ? l.disabledSuffix : ''}`.trim()
+
+  const isFilled = selectedItems.length > 0
+
   return (
-    <Group
-      css={selectContainerStyles(size)}
-      style={rest.style}
+    <FieldWrapper
       className='ds-select-input-container'
-      tabIndex={disabled ? 0 : undefined}
-      aria-disabled={disabled}
-      aria-label={disabled ? totalAriaLabel : undefined}
+      label={label}
+      caption={caption}
+      errorMessage={errorMessage}
+      required={required}
+      disabled={disabled}
+      size={size}
+      showOptionalLabel={false}
+      semantics='group'
+      style={style}
+      containerProps={{
+        tabIndex: disabled ? 0 : undefined,
+        'aria-disabled': disabled,
+        'aria-label': disabled ? totalAriaLabel : undefined,
+      }}
     >
-      {errorMessage ? <div css={selectErrorBarStyles} /> : null}
       <SelectRoot
         css={{}}
         collection={selectItems}
@@ -146,25 +159,12 @@ const Select = ({
         onValueChange={(details: SelectValueChangeDetails) =>
           onChangeHandler(details.value)
         }
-        style={{ marginLeft: errorMessage ? '1.1875rem' : '0px' }}
         {...rest}
       >
-        {label ? (
-          <SelectLabel css={selectLabelStyles(size)}>
-            {required ? <span>*</span> : null}
-            {label}
-          </SelectLabel>
-        ) : null}
-        {caption ? (
-          <p css={selectCaptionStyles(size, disabled)}>{caption}</p>
-        ) : null}
-        {errorMessage && (
-          <p css={selectErrorMessageStyles(size)}>{errorMessage}</p>
-        )}
         <SelectTrigger
           css={selectTriggerStyles(
             size,
-            selectedItems.length > 0,
+            isFilled,
             !!errorMessage,
             multiple,
           )}
@@ -203,7 +203,7 @@ const Select = ({
           ))}
         </SelectContent>
       </SelectRoot>
-    </Group>
+    </FieldWrapper>
   )
 }
 

--- a/src/components/Forms/Inputs/Select/index.tsx
+++ b/src/components/Forms/Inputs/Select/index.tsx
@@ -162,12 +162,7 @@ const Select = ({
         {...rest}
       >
         <SelectTrigger
-          css={selectTriggerStyles(
-            size,
-            isFilled,
-            !!errorMessage,
-            multiple,
-          )}
+          css={selectTriggerStyles(size, isFilled, !!errorMessage, multiple)}
           aria-label={rest['aria-label'] || label || l.defaultAriaLabel}
         >
           {multiple ? (

--- a/src/components/Forms/Inputs/Select/styled.ts
+++ b/src/components/Forms/Inputs/Select/styled.ts
@@ -7,68 +7,7 @@ import {
   getThemedRadius,
   getThemedSpacing,
 } from '../../../../lib/theme'
-
-export const selectContainerStyles = (size: string) => css`
-  position: relative;
-  height: 100%;
-  width: 100%;
-  display: flex;
-  justify-content: flex-start;
-  align-items: flex-start;
-  gap: ${size === 'small' ? getThemedSpacing(300) : getThemedSpacing(400)};
-  margin-bottom: ${getThemedSpacing(400)};
-  &:focus-visible {
-    outline-color: ${getThemedColor('primary', 700)};
-  }
-`
-
-export const selectErrorBarStyles = css`
-  width: 0.1875rem;
-  height: 100%;
-  background-color: ${getThemedColor('error', 900)};
-  position: absolute;
-  top: 0;
-  left: 0;
-`
-
-export const selectLabelStyles = (size: string) => css`
-  font-size: ${size === 'small'
-    ? getThemedFontSize(300)
-    : getThemedFontSize(400)};
-  line-height: ${size === 'small'
-    ? getThemedLineHeight(500)
-    : getThemedLineHeight(600)};
-  font-weight: 400;
-  color: ${getThemedColor('neutral', 900)};
-  text-align: left;
-
-  span {
-    color: ${getThemedColor('error', 500)};
-    margin-right: 0.1875rem;
-  }
-
-  &[data-disabled] {
-    color: ${getThemedColor('neutral', 600)};
-
-    span {
-      color: ${getThemedColor('neutral', 600)};
-    }
-  }
-`
-
-export const selectCaptionStyles = (size: string, disabled?: boolean) => css`
-  font-size: ${size === 'small'
-    ? getThemedFontSize(200)
-    : getThemedFontSize(300)};
-  line-height: ${size === 'small'
-    ? getThemedLineHeight(400)
-    : getThemedLineHeight(500)};
-  font-weight: 400;
-  color: ${getThemedColor('neutral', 700)};
-  text-align: left;
-
-  ${disabled ? `color: ${getThemedColor('neutral', 600)} !important;` : ''}
-`
+import { fieldFocusVisibleStyles } from '../FieldWrapper/styled'
 
 const getTriggerBorderColor = (isFilled: boolean, hasErrorMessage: boolean) => {
   if (hasErrorMessage) {
@@ -84,10 +23,23 @@ export const selectTriggerStyles = (
   hasErrorMessage: boolean,
   multiple?: boolean,
 ) => css`
+  border-radius: ${getThemedRadius(300)};
+  overflow: visible;
+
+  &:has(
+      .chakra-select__trigger:is(
+          :focus-visible,
+          [data-focus-visible],
+          [data-state='open']
+        )
+    ) {
+    ${fieldFocusVisibleStyles}
+  }
+
   .chakra-select__trigger {
     min-height: ${size === 'small'
-      ? getThemedSpacing(800)
-      : getThemedSpacing(1000)};
+    ? getThemedSpacing(800)
+    : getThemedSpacing(1000)};
     border-radius: ${getThemedRadius(300)};
     padding: ${getThemedSpacing(50)} ${getThemedSpacing(200)};
     border: ${getThemedBorderWidth(100)} solid
@@ -98,37 +50,39 @@ export const selectTriggerStyles = (
 
     .chakra-select__valueText {
       font-size: ${size === 'small'
-        ? getThemedFontSize(300)
-        : getThemedFontSize(400)};
+    ? getThemedFontSize(300)
+    : getThemedFontSize(400)};
       line-height: ${size === 'small'
-        ? getThemedLineHeight(500)
-        : getThemedLineHeight(600)};
+    ? getThemedLineHeight(500)
+    : getThemedLineHeight(600)};
       color: ${getThemedColor('neutral', 700)};
 
       ${multiple
-        ? `
+    ? `
         display: flex;
         flex-wrap: wrap;
         gap: ${getThemedSpacing(200)};
       `
-        : ''}
+    : ''}
     }
 
     &[data-state='open'] {
       border-bottom-left-radius: 0;
       border-bottom-right-radius: 0;
-      border-bottom: none;
-    }
+      border-bottom-color: transparent;
 
-    &:is(:focus-visible, [data-focus-visible]) {
-      outline-offset: ${getThemedSpacing(50)};
-      outline-width: ${getThemedBorderWidth(200)};
-      outline-color: ${getThemedColor('primary', 700)};
-      border: ${getThemedBorderWidth(200)} solid
-        ${getThemedColor('neutral', 700)};
-      box-shadow:
-        0 0 0 0.125rem ${getThemedColor('neutral', 100)},
-        rgba(0, 0, 0, 0.05) 0 0.125rem 0.125rem 0.25rem;
+      &[data-placement^='top'] {
+        border-bottom-left-radius: ${getThemedRadius(300)};
+        border-bottom-right-radius: ${getThemedRadius(300)};
+        border-bottom-color: ${getTriggerBorderColor(
+      isFilled,
+      hasErrorMessage,
+    )};
+
+        border-top-left-radius: 0;
+        border-top-right-radius: 0;
+        border-top-color: transparent;
+      }
     }
 
     &[data-disabled] {
@@ -141,8 +95,8 @@ export const selectTriggerStyles = (
   .chakra-select__indicator {
     svg {
       width: ${size === 'small'
-        ? getThemedSpacing(300)
-        : getThemedSpacing(400)};
+    ? getThemedSpacing(300)
+    : getThemedSpacing(400)};
 
       path {
         fill: ${getThemedColor('neutral', 700)};
@@ -157,12 +111,28 @@ export const selectTriggerStyles = (
   }
 `
 export const selectContentStyles = css`
-  margin-top: -${getThemedSpacing(200)};
+  margin-top: calc(${getThemedSpacing(200)} * -1);
   border-radius: ${getThemedRadius(300)};
   border: ${getThemedBorderWidth(100)} solid ${getThemedColor('neutral', 400)};
   border-top-left-radius: 0;
   border-top-right-radius: 0;
-  border-top: none;
+  box-shadow:
+    0 0.25rem 0.375rem -0.25rem #0000001a,
+    0 0.625rem 0.9375rem -0.1875rem #0000001a;
+
+  &[data-placement^='top'] {
+    margin-top: 0;
+    margin-bottom: calc(${getThemedSpacing(200)} * -1);
+    border-top-left-radius: ${getThemedRadius(300)};
+    border-top-right-radius: ${getThemedRadius(300)};
+    border-top: ${getThemedBorderWidth(100)} solid
+      ${getThemedColor('neutral', 400)};
+    border-bottom-left-radius: 0;
+    border-bottom-right-radius: 0;
+    box-shadow:
+      0 -0.25rem 0.375rem -0.25rem #0000001a,
+      0 -0.625rem 0.9375rem -0.1875rem #0000001a;
+  }
 `
 
 export const selectItemStyles = css`
@@ -182,6 +152,7 @@ export const selectItemLabelStyles = (size: string, disabled?: boolean) => css`
     : getThemedLineHeight(600)};
   color: ${getThemedColor('neutral', 800)};
   text-align: left;
+  margin: 0;
 
   ${disabled ? `color: ${getThemedColor('neutral', 600)} !important;` : ''}
 `
@@ -198,18 +169,7 @@ export const selectItemCaptionStyles = (
     : getThemedLineHeight(600)};
   color: ${getThemedColor('neutral', 700)};
   text-align: left;
+  margin: 0;
 
   ${disabled ? `color: ${getThemedColor('neutral', 600)} !important;` : ''}
-`
-
-export const selectErrorMessageStyles = (size: string) => css`
-  font-size: ${size === 'small'
-    ? getThemedFontSize(200)
-    : getThemedFontSize(300)};
-  line-height: ${size === 'small'
-    ? getThemedLineHeight(400)
-    : getThemedLineHeight(500)};
-  font-weight: 700;
-  color: ${getThemedColor('error', 900)};
-  text-align: left;
 `

--- a/src/components/Forms/Inputs/Select/styled.ts
+++ b/src/components/Forms/Inputs/Select/styled.ts
@@ -38,8 +38,8 @@ export const selectTriggerStyles = (
 
   .chakra-select__trigger {
     min-height: ${size === 'small'
-    ? getThemedSpacing(800)
-    : getThemedSpacing(1000)};
+      ? getThemedSpacing(800)
+      : getThemedSpacing(1000)};
     border-radius: ${getThemedRadius(300)};
     padding: ${getThemedSpacing(50)} ${getThemedSpacing(200)};
     border: ${getThemedBorderWidth(100)} solid
@@ -50,20 +50,20 @@ export const selectTriggerStyles = (
 
     .chakra-select__valueText {
       font-size: ${size === 'small'
-    ? getThemedFontSize(300)
-    : getThemedFontSize(400)};
+        ? getThemedFontSize(300)
+        : getThemedFontSize(400)};
       line-height: ${size === 'small'
-    ? getThemedLineHeight(500)
-    : getThemedLineHeight(600)};
+        ? getThemedLineHeight(500)
+        : getThemedLineHeight(600)};
       color: ${getThemedColor('neutral', 700)};
 
       ${multiple
-    ? `
+        ? `
         display: flex;
         flex-wrap: wrap;
         gap: ${getThemedSpacing(200)};
       `
-    : ''}
+        : ''}
     }
 
     &[data-state='open'] {
@@ -75,9 +75,9 @@ export const selectTriggerStyles = (
         border-bottom-left-radius: ${getThemedRadius(300)};
         border-bottom-right-radius: ${getThemedRadius(300)};
         border-bottom-color: ${getTriggerBorderColor(
-      isFilled,
-      hasErrorMessage,
-    )};
+          isFilled,
+          hasErrorMessage,
+        )};
 
         border-top-left-radius: 0;
         border-top-right-radius: 0;
@@ -95,8 +95,8 @@ export const selectTriggerStyles = (
   .chakra-select__indicator {
     svg {
       width: ${size === 'small'
-    ? getThemedSpacing(300)
-    : getThemedSpacing(400)};
+        ? getThemedSpacing(300)
+        : getThemedSpacing(400)};
 
       path {
         fill: ${getThemedColor('neutral', 700)};

--- a/src/components/Forms/Inputs/SliderInput/index.tsx
+++ b/src/components/Forms/Inputs/SliderInput/index.tsx
@@ -112,8 +112,7 @@ const SliderInput = ({
           <Select
             items={sliderItem.marks.map((mark) => {
               const markValue = typeof mark === 'number' ? mark : mark.value
-              const markLabel =
-                typeof mark === 'number' ? mark : mark.label
+              const markLabel = typeof mark === 'number' ? mark : mark.label
               return {
                 label: `${markLabel}`,
                 value: `${markValue}`,

--- a/src/components/Forms/Inputs/SliderInput/index.tsx
+++ b/src/components/Forms/Inputs/SliderInput/index.tsx
@@ -4,14 +4,11 @@
 import React, { useState } from 'react'
 
 import { SliderInputProps } from './types'
-import {
-  sliderInputCaptionStyles,
-  sliderInputContentStyles,
-  sliderInputLabelStyles,
-} from './styled'
+import { sliderInputContentStyles } from './styled'
 import TextInput from '../TextInput'
 import Slider from '../../Controls/Slider'
 import Select from '../Select'
+import FieldWrapper from '../FieldWrapper'
 
 const SliderInput = ({
   label,
@@ -101,24 +98,27 @@ const SliderInput = ({
   }
 
   return (
-    <div>
-      <p css={sliderInputLabelStyles(size)} aria-label={label}>
-        {required ? <span>*</span> : null}
-        {label}
-      </p>
-      {caption ? (
-        <p css={sliderInputCaptionStyles(size)} aria-label={caption}>
-          {caption}
-        </p>
-      ) : null}
-
+    <FieldWrapper
+      label={label}
+      caption={caption}
+      required={required}
+      size={size}
+      showOptionalLabel={false}
+      noMarginBottom
+      semantics='group'
+    >
       <div css={sliderInputContentStyles}>
         {sliderItem.step && sliderItem.marks ? (
           <Select
-            items={sliderItem.marks.map((mark: any) => ({
-              label: `${mark.label}`,
-              value: `${mark.value}`,
-            }))}
+            items={sliderItem.marks.map((mark) => {
+              const markValue = typeof mark === 'number' ? mark : mark.value
+              const markLabel =
+                typeof mark === 'number' ? mark : mark.label
+              return {
+                label: `${markLabel}`,
+                value: `${markValue}`,
+              }
+            })}
             placeholder=''
             style={{ width: '5.625rem' }}
             value={[`${value?.[0]}`]}
@@ -134,7 +134,10 @@ const SliderInput = ({
             onChange={(e) => handleInputChanged(e, 0)}
             onBlur={(e) => handleInputBlur(e, 0)}
             className='ds-opacity-control-text-input'
-            onClick={(e: any) => e.target.select()}
+            onClick={(e: React.MouseEvent<HTMLInputElement>) =>
+              (e.target as HTMLInputElement).select()
+            }
+            noMarginBottom
           />
         )}
         <Slider
@@ -158,11 +161,14 @@ const SliderInput = ({
             onChange={(e) => handleInputChanged(e, 1)}
             onBlur={(e) => handleInputBlur(e, 1)}
             className='ds-opacity-control-text-input'
-            onClick={(e: any) => e.target.select()}
+            onClick={(e: React.MouseEvent<HTMLInputElement>) =>
+              (e.target as HTMLInputElement).select()
+            }
+            noMarginBottom
           />
         ) : null}
       </div>
-    </div>
+    </FieldWrapper>
   )
 }
 

--- a/src/components/Forms/Inputs/SliderInput/styled.ts
+++ b/src/components/Forms/Inputs/SliderInput/styled.ts
@@ -1,40 +1,5 @@
 import { css } from '@emotion/react'
-import {
-  getThemedColor,
-  getThemedFontSize,
-  getThemedLineHeight,
-  getThemedSpacing,
-} from '../../../../lib/theme'
-import { SliderInputProps } from './types'
-
-export const sliderInputLabelStyles = (size: SliderInputProps['size']) => css`
-  font-size: ${size === 'small'
-    ? getThemedFontSize(300)
-    : getThemedFontSize(400)};
-  line-height: ${size === 'small'
-    ? getThemedLineHeight(500)
-    : getThemedLineHeight(600)};
-  font-weight: 400;
-  color: ${getThemedColor('neutral', 900)};
-  text-align: left;
-
-  span {
-    color: ${getThemedColor('error', 500)};
-    margin-right: 0.1875rem;
-  }
-`
-
-export const sliderInputCaptionStyles = (size: SliderInputProps['size']) => css`
-  font-size: ${size === 'small'
-    ? getThemedFontSize(200)
-    : getThemedFontSize(300)};
-  line-height: ${size === 'small'
-    ? getThemedLineHeight(400)
-    : getThemedLineHeight(500)};
-  font-weight: 400;
-  color: ${getThemedColor('neutral', 700)};
-  text-align: left;
-`
+import { getThemedSpacing } from '../../../../lib/theme'
 
 export const sliderInputContentStyles = css`
   display: flex;
@@ -49,6 +14,10 @@ export const sliderInputContentStyles = css`
       padding: ${getThemedSpacing(100)};
       width: 3.9375rem;
     }
+  }
+
+  .ds-select-input-container {
+    margin-bottom: 0;
   }
 
   .chakra-slider__root {

--- a/src/components/Forms/Inputs/TextInput/TextInput.stories.tsx
+++ b/src/components/Forms/Inputs/TextInput/TextInput.stories.tsx
@@ -107,6 +107,16 @@ export const DefaultValue: Story = {
   },
 }
 
+export const DisabledWithDefaultValue: Story = {
+  args: {
+    label: 'Label',
+    caption: 'Caption',
+    defaultValue: 'Default Value',
+    required: true,
+    disabled: true,
+  },
+}
+
 export const WithError: Story = {
   args: {
     label: 'Label',

--- a/src/components/Forms/Inputs/TextInput/TextInputDemo.tsx
+++ b/src/components/Forms/Inputs/TextInput/TextInputDemo.tsx
@@ -3,7 +3,7 @@ import DemoWrapper from '../../../UI/DemoWrapper'
 
 const TextInputDemo = () => (
   <DemoWrapper title='Text Input'>
-    <div style={{ width: '18.125rem' }}>
+    <div style={{ width: '18.125rem', flexDirection: 'column', display: 'flex', gap: '1.25rem' }} >
       <TextInput
         label='Label'
         caption='Caption'

--- a/src/components/Forms/Inputs/TextInput/TextInputDemo.tsx
+++ b/src/components/Forms/Inputs/TextInput/TextInputDemo.tsx
@@ -3,7 +3,14 @@ import DemoWrapper from '../../../UI/DemoWrapper'
 
 const TextInputDemo = () => (
   <DemoWrapper title='Text Input'>
-    <div style={{ width: '18.125rem', flexDirection: 'column', display: 'flex', gap: '1.25rem' }} >
+    <div
+      style={{
+        width: '18.125rem',
+        flexDirection: 'column',
+        display: 'flex',
+        gap: '1.25rem',
+      }}
+    >
       <TextInput
         label='Label'
         caption='Caption'

--- a/src/components/Forms/Inputs/TextInput/index.tsx
+++ b/src/components/Forms/Inputs/TextInput/index.tsx
@@ -3,17 +3,11 @@
 
 import React, { useState } from 'react'
 
-import { Field, Input } from '@chakra-ui/react'
-import {
-  fieldCaptionStyles,
-  fieldErrorMessageStyles,
-  fieldLabelStyles,
-  textInputContainerStyles,
-  textInputErrorBarStyles,
-  textInputStyles,
-} from './styled'
+import { Input } from '@chakra-ui/react'
+import { textInputStyles } from './styled'
 import { TextInputProps } from './types'
 import { useLabels } from '../../../../lib/i18n/useLabels'
+import FieldWrapper from '../FieldWrapper'
 
 const TextInput = ({
   label,
@@ -28,72 +22,57 @@ const TextInput = ({
   defaultValue = '',
   onChange,
   labels,
+  value: controlledValue,
   ...rest
 }: TextInputProps) => {
   const l = useLabels('TextInput', labels)
-  const [value, setValue] = useState(defaultValue)
+  const [uncontrolledValue, setUncontrolledValue] = useState(defaultValue)
+  const isControlled = controlledValue !== undefined
+  const currentValue = isControlled
+    ? String(controlledValue ?? '')
+    : uncontrolledValue
 
   const handleOnChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    setValue(e.target.value)
+    if (!isControlled) {
+      setUncontrolledValue(e.target.value)
+    }
 
     if (onChange) {
       onChange(e)
     }
   }
 
+  const isFilled = Boolean(currentValue || defaultValue)
+
   return (
-    <div
-      css={textInputContainerStyles(size, noMarginBottom)}
+    <FieldWrapper
       className='ds-text-input-container'
+      label={label}
+      caption={caption}
+      errorMessage={errorMessage}
+      required={required}
+      disabled={disabled}
+      size={size}
+      showOptionalLabel={showOptionalLabel}
+      noMarginBottom={noMarginBottom}
+      labels={{
+        requiredSymbolLabel: l.requiredSymbolLabel,
+        optionalSuffix: l.optionalSuffix,
+      }}
+      semantics='field'
     >
-      {errorMessage ? <div css={textInputErrorBarStyles} /> : null}
-      <Field.Root
-        required={required}
-        invalid={!!errorMessage}
-        gap='0'
-        style={{ marginLeft: errorMessage ? '1.1875rem' : '0px' }}
-      >
-        {label ? (
-          <Field.Label
-            css={fieldLabelStyles(size, disabled)}
-            aria-label={label}
-          >
-            <Field.RequiredIndicator aria-label={l.requiredSymbolLabel} />
-            {label}
-            {!required && showOptionalLabel ? (
-              <span>{l.optionalSuffix}</span>
-            ) : null}
-          </Field.Label>
-        ) : null}
-        {caption ? (
-          <Field.HelperText
-            css={fieldCaptionStyles(size, disabled)}
-            aria-label={caption}
-          >
-            {caption}
-          </Field.HelperText>
-        ) : null}
-        {errorMessage ? (
-          <Field.ErrorText
-            css={fieldErrorMessageStyles(size)}
-            aria-label={errorMessage}
-          >
-            {errorMessage}
-          </Field.ErrorText>
-        ) : null}
-        <Input
-          placeholder={placeholder}
-          disabled={disabled}
-          css={textInputStyles(size, value, defaultValue)}
-          onChange={handleOnChange}
-          value={value}
-          _placeholder={{
-            color: 'var(--chakra-colors-neutral-500)',
-          }}
-          {...rest}
-        />
-      </Field.Root>
-    </div>
+      <Input
+        placeholder={placeholder}
+        disabled={disabled}
+        css={textInputStyles(size, isFilled)}
+        onChange={handleOnChange}
+        value={currentValue}
+        _placeholder={{
+          color: 'var(--chakra-colors-neutral-500)',
+        }}
+        {...rest}
+      />
+    </FieldWrapper>
   )
 }
 

--- a/src/components/Forms/Inputs/TextInput/styled.ts
+++ b/src/components/Forms/Inputs/TextInput/styled.ts
@@ -3,102 +3,15 @@ import {
   getThemedBorderWidth,
   getThemedColor,
   getThemedFontSize,
-  getThemedLineHeight,
   getThemedRadius,
   getThemedSpacing,
 } from '../../../../lib/theme'
+import { fieldFocusVisibleStyles } from '../FieldWrapper/styled'
 import { TextInputProps } from './types'
-
-export const textInputContainerStyles = (
-  size: TextInputProps['size'],
-  noMarginBottom?: boolean,
-) => css`
-  position: relative;
-  height: 100%;
-  width: 100%;
-  display: flex;
-  justify-content: flex-start;
-  align-items: flex-start;
-  gap: ${size === 'small' ? getThemedSpacing(300) : getThemedSpacing(400)};
-  margin-bottom: ${noMarginBottom ? '0' : getThemedSpacing(500)};
-`
-
-export const textInputErrorBarStyles = css`
-  width: 0.1875rem;
-  height: 100%;
-  background-color: ${getThemedColor('error', 900)};
-  position: absolute;
-  top: 0;
-  left: 0;
-`
-
-export const fieldLabelStyles = (
-  size: TextInputProps['size'],
-  disabled?: TextInputProps['disabled'],
-) => css`
-  color: ${getThemedColor('neutral', disabled ? 600 : 900)};
-  font-size: ${size === 'small'
-    ? getThemedFontSize(300)
-    : getThemedFontSize(400)};
-  font-weight: 400;
-  line-height: ${size === 'small'
-    ? getThemedLineHeight(500)
-    : getThemedLineHeight(600)};
-  margin-bottom: ${getThemedSpacing(50)};
-  display: flex;
-  align-items: flex-start;
-  -webkit-user-select: text;
-  -moz-user-select: text;
-  -ms-user-select: text;
-  user-select: text;
-  cursor: text;
-
-  span {
-    color: ${getThemedColor('neutral', disabled ? 600 : 700)};
-  }
-
-  .chakra-field__requiredIndicator {
-    margin-top: ${getThemedSpacing(100)};
-    color: ${disabled
-      ? getThemedColor('neutral', 600)
-      : getThemedColor('error', 500)};
-  }
-`
-
-export const fieldCaptionStyles = (
-  size: TextInputProps['size'],
-  disabled?: TextInputProps['disabled'],
-) => css`
-  color: ${getThemedColor('neutral', disabled ? 600 : 700)};
-  font-size: ${size === 'small'
-    ? getThemedFontSize(200)
-    : getThemedFontSize(300)};
-  font-weight: 400;
-  line-height: ${size === 'small'
-    ? getThemedLineHeight(400)
-    : getThemedLineHeight(500)};
-
-  &:first-letter {
-    text-transform: uppercase;
-  }
-`
-
-export const fieldErrorMessageStyles = (size: TextInputProps['size']) => css`
-  color: ${getThemedColor('error', 900)};
-  font-size: ${size === 'small'
-    ? getThemedFontSize(200)
-    : getThemedFontSize(300)};
-  font-weight: 700;
-  line-height: ${size === 'small'
-    ? getThemedLineHeight(400)
-    : getThemedLineHeight(500)};
-  margin-top: ${getThemedSpacing(50)};
-`
 
 export const textInputStyles = (
   size: TextInputProps['size'],
-  value?: string,
-  defaultValue?: string,
+  isFilled?: boolean,
 ) => css`
   height: ${size === 'small' ? getThemedSpacing(700) : getThemedSpacing(1000)};
   width: 100%;
@@ -116,12 +29,7 @@ export const textInputStyles = (
 
   &:focus-visible,
   &[data-focus-visible] {
-    outline: ${getThemedBorderWidth(200)} solid
-      ${getThemedColor('primary', 700)};
-    outline-offset: ${getThemedSpacing(50)};
-    box-shadow:
-      0 0 0 0.125rem ${getThemedColor('neutral', 100)},
-      rgba(0, 0, 0, 0.05) 0 0.125rem 0.125rem 0.25rem;
+    ${fieldFocusVisibleStyles}
   }
 
   &[data-invalid] {
@@ -133,7 +41,7 @@ export const textInputStyles = (
     border: ${getThemedBorderWidth(100)} solid ${getThemedColor('neutral', 300)} !important;
   }
 
-  ${value || defaultValue
+  ${isFilled
     ? `
     border: ${getThemedBorderWidth(100)} solid ${getThemedColor('neutral', 700)};
   `

--- a/src/components/Forms/Inputs/Textarea/TextareaDemo.tsx
+++ b/src/components/Forms/Inputs/Textarea/TextareaDemo.tsx
@@ -3,7 +3,14 @@ import DemoWrapper from '../../../UI/DemoWrapper'
 
 const TextareaDemo = () => (
   <DemoWrapper title='Textarea'>
-    <div style={{ width: '18.125rem', flexDirection: 'column', display: 'flex', gap: '1.25rem' }} >
+    <div
+      style={{
+        width: '18.125rem',
+        flexDirection: 'column',
+        display: 'flex',
+        gap: '1.25rem',
+      }}
+    >
       <Textarea
         label='Label'
         caption='Caption'

--- a/src/components/Forms/Inputs/Textarea/TextareaDemo.tsx
+++ b/src/components/Forms/Inputs/Textarea/TextareaDemo.tsx
@@ -3,7 +3,7 @@ import DemoWrapper from '../../../UI/DemoWrapper'
 
 const TextareaDemo = () => (
   <DemoWrapper title='Textarea'>
-    <div style={{ width: '18.125rem' }}>
+    <div style={{ width: '18.125rem', flexDirection: 'column', display: 'flex', gap: '1.25rem' }} >
       <Textarea
         label='Label'
         caption='Caption'

--- a/src/components/Forms/Inputs/Textarea/index.tsx
+++ b/src/components/Forms/Inputs/Textarea/index.tsx
@@ -5,15 +5,12 @@ import React, { useEffect, useState, useId } from 'react'
 import { Field, Textarea as ChakraTextarea } from '@chakra-ui/react'
 import { TextareaProps } from './types'
 import {
-  fieldCaptionStyles,
   fieldErrorMessageStyles,
   fieldHelperTextStyles,
-  fieldLabelStyles,
-  textareaContainerStyles,
-  textareaErrorBarStyles,
   textareaSyles,
 } from './styled'
 import { useLabels } from '../../../../lib/i18n/useLabels'
+import FieldWrapper from '../FieldWrapper'
 
 const Textarea = ({
   label,
@@ -29,13 +26,19 @@ const Textarea = ({
   minLength,
   maxLength,
   labels,
+  value: controlledValue,
   ...rest
 }: TextareaProps) => {
   const l = useLabels('Textarea', labels)
-  const [value, setValue] = useState(defaultValue)
+  const [uncontrolledValue, setUncontrolledValue] = useState(defaultValue)
   const [showMinLengthError, setShowMinLengthError] = useState(false)
   const [showMaxLengthError, setShowMaxLengthError] = useState(false)
   const [helperText, setHelperText] = useState('')
+
+  const isControlled = controlledValue !== undefined
+  const currentValue = isControlled
+    ? String(controlledValue ?? '')
+    : uncontrolledValue
 
   const captionId = useId()
   const errorId = useId()
@@ -60,7 +63,9 @@ const Textarea = ({
   }, [])
 
   const handleOnChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
-    setValue(e.target.value)
+    if (!isControlled) {
+      setUncontrolledValue(e.target.value)
+    }
     const { length } = e.target.value
 
     if (minLength && maxLength) {
@@ -95,103 +100,91 @@ const Textarea = ({
       .filter(Boolean)
       .join(' ') || undefined
 
-  return (
-    <div css={textareaContainerStyles(size)}>
-      {hasError ? <div css={textareaErrorBarStyles} /> : null}
-      <Field.Root
-        required={required}
-        invalid={hasError}
-        gap='0'
-        style={{ marginLeft: hasError ? '1.1875rem' : '0px' }}
-      >
-        {label ? (
-          <Field.Label
-            css={fieldLabelStyles(size, disabled)}
-            aria-label={label}
-          >
-            <Field.RequiredIndicator aria-label={l.requiredSymbolLabel} />
-            {label}
-            {!required && showOptionalLabel ? (
-              <span>{l.optionalSuffix}</span>
-            ) : null}
-          </Field.Label>
-        ) : null}
+  const isFilled = Boolean(currentValue || defaultValue)
 
-        {caption ? (
-          <Field.HelperText
-            id={captionId}
-            css={fieldCaptionStyles(size, disabled)}
-          >
-            {caption}
-          </Field.HelperText>
-        ) : null}
+  const showHelperText =
+    helperText && !showMaxLengthError && !showMinLengthError
+  const hasFooterContent =
+    (showMinLengthError && !!minLength) ||
+    (showMaxLengthError && !!maxLength) ||
+    showHelperText
 
-        {errorMessage ? (
-          <Field.ErrorText
-            id={errorId}
-            css={fieldErrorMessageStyles}
-            aria-label={`${l.errorPrefix} ${errorMessage}`}
-            aria-live='polite'
-          >
-            {errorMessage}
-          </Field.ErrorText>
-        ) : null}
-
-        <ChakraTextarea
-          placeholder={placeholder}
-          disabled={disabled}
-          css={textareaSyles(size, value, defaultValue)}
-          onChange={handleOnChange}
-          value={value}
-          aria-label={label || placeholder}
-          aria-describedby={describedByIds}
-          _placeholder={{
-            color: 'var(--chakra-colors-neutral-500)',
+  const footer = hasFooterContent ? (
+    <>
+      {showMinLengthError && minLength ? (
+        <Field.ErrorText
+          id={errorId}
+          css={fieldErrorMessageStyles}
+          style={{
+            fontSize: '0.75rem',
+            lineHeight: '1rem',
           }}
-          {...rest}
-        />
+          aria-live='polite'
+        >
+          {l.needMoreChars(minLength - currentValue.length)}
+        </Field.ErrorText>
+      ) : null}
 
-        {showMinLengthError && minLength ? (
-          <Field.ErrorText
-            id={errorId}
-            css={fieldErrorMessageStyles}
-            style={{
-              marginTop: '0.5rem',
-              fontSize: '0.75rem',
-              lineHeight: '1rem',
-            }}
-            aria-live='polite'
-          >
-            {l.needMoreChars(minLength - value.length)}
-          </Field.ErrorText>
-        ) : null}
+      {showMaxLengthError && maxLength ? (
+        <Field.ErrorText
+          id={errorId}
+          css={fieldErrorMessageStyles}
+          style={{
+            fontSize: '0.75rem',
+            lineHeight: '1rem',
+          }}
+          aria-live='polite'
+        >
+          {l.tooManyChars(currentValue.length - maxLength)}
+        </Field.ErrorText>
+      ) : null}
 
-        {showMaxLengthError && maxLength ? (
-          <Field.ErrorText
-            id={errorId}
-            css={fieldErrorMessageStyles}
-            style={{
-              marginTop: '0.5rem',
-              fontSize: '0.75rem',
-              lineHeight: '1rem',
-            }}
-            aria-live='polite'
-          >
-            {l.tooManyChars(value.length - maxLength)}
-          </Field.ErrorText>
-        ) : null}
+      {showHelperText ? (
+        <Field.HelperText
+          id={helperId}
+          css={fieldHelperTextStyles}
+          aria-live='polite'
+        >
+          {helperText}
+        </Field.HelperText>
+      ) : null}
+    </>
+  ) : null
 
-        {helperText && !showMaxLengthError && !showMinLengthError ? (
-          <Field.HelperText
-            id={helperId}
-            css={fieldHelperTextStyles}
-            aria-live='polite'
-          >
-            {helperText}
-          </Field.HelperText>
-        ) : null}
-      </Field.Root>
-    </div>
+  return (
+    <FieldWrapper
+      label={label}
+      caption={caption}
+      errorMessage={errorMessage}
+      invalid={hasError}
+      required={required}
+      disabled={disabled}
+      size={size}
+      showOptionalLabel={showOptionalLabel}
+      labels={{
+        requiredSymbolLabel: l.requiredSymbolLabel,
+        optionalSuffix: l.optionalSuffix,
+      }}
+      captionId={captionId}
+      errorId={errorMessage ? errorId : undefined}
+      footer={footer}
+      semantics='field'
+    >
+      <ChakraTextarea
+        placeholder={placeholder}
+        disabled={disabled}
+        css={textareaSyles(size, isFilled)}
+        onChange={handleOnChange}
+        value={currentValue}
+        aria-label={label || placeholder}
+        aria-describedby={describedByIds}
+        aria-invalid={hasError || undefined}
+        _placeholder={{
+          color: 'var(--chakra-colors-neutral-500)',
+        }}
+        {...rest}
+      />
+    </FieldWrapper>
   )
 }
 

--- a/src/components/Forms/Inputs/Textarea/styled.ts
+++ b/src/components/Forms/Inputs/Textarea/styled.ts
@@ -7,72 +7,15 @@ import {
   getThemedRadius,
   getThemedSpacing,
 } from '../../../../lib/theme'
+import { fieldFocusVisibleStyles } from '../FieldWrapper/styled'
 import { TextareaProps } from './types'
-
-export const textareaContainerStyles = (size: TextareaProps['size']) => css`
-  position: relative;
-  height: 100%;
-  width: 100%;
-  display: flex;
-  justify-content: flex-start;
-  align-items: flex-start;
-  gap: ${size === 'small' ? getThemedSpacing(300) : getThemedSpacing(400)};
-  margin-bottom: ${getThemedSpacing(400)};
-`
-export const textareaErrorBarStyles = css`
-  width: 0.1875rem;
-  height: 100%;
-  background-color: ${getThemedColor('error', 900)};
-  position: absolute;
-  top: 0;
-  left: 0;
-`
-
-export const fieldLabelStyles = (
-  size: TextareaProps['size'],
-  disabled?: TextareaProps['disabled'],
-) => css`
-  color: ${getThemedColor('neutral', disabled ? 600 : 900)};
-  font-size: ${size === 'small'
-    ? getThemedFontSize(300)
-    : getThemedFontSize(400)};
-  font-weight: 400;
-  line-height: ${size === 'small'
-    ? getThemedLineHeight(500)
-    : getThemedLineHeight(600)};
-  margin-bottom: ${getThemedSpacing(50)};
-
-  span {
-    color: ${getThemedColor('neutral', disabled ? 600 : 700)};
-  }
-
-  .chakra-field__requiredIndicator {
-    color: ${disabled
-      ? getThemedColor('neutral', 600)
-      : getThemedColor('error', 500)};
-  }
-`
-
-export const fieldCaptionStyles = (
-  size: TextareaProps['size'],
-  disabled?: TextareaProps['disabled'],
-) => css`
-  color: ${getThemedColor('neutral', disabled ? 600 : 700)};
-  font-size: ${size === 'small'
-    ? getThemedFontSize(200)
-    : getThemedFontSize(300)};
-  font-weight: 400;
-  line-height: ${size === 'small'
-    ? getThemedLineHeight(400)
-    : getThemedLineHeight(500)};
-`
 
 export const fieldHelperTextStyles = css`
   color: ${getThemedColor('neutral', 600)};
   font-size: ${getThemedFontSize(200)};
   font-weight: 400;
   line-height: ${getThemedLineHeight(400)};
-  margin-top: ${getThemedSpacing(200)};
+  margin: 0;
 `
 
 export const fieldErrorMessageStyles = css`
@@ -80,19 +23,17 @@ export const fieldErrorMessageStyles = css`
   font-size: ${getThemedFontSize(300)};
   font-weight: 700;
   line-height: ${getThemedLineHeight(500)};
-  margin-top: ${getThemedSpacing(50)};
+  margin: 0;
 `
 
 export const textareaSyles = (
   size: TextareaProps['size'],
-  value?: string,
-  defaultValue?: string,
+  isFilled?: boolean,
 ) => css`
   height: 6.5rem;
   width: 100%;
   border-radius: ${getThemedRadius(300)};
   padding: ${size === 'small' ? getThemedSpacing(200) : getThemedSpacing(300)};
-  margin-top: ${getThemedSpacing(200)};
   background-color: ${getThemedColor('neutral', 100)};
   color: ${getThemedColor('neutral', 800)};
   border: ${getThemedBorderWidth(100)} solid ${getThemedColor('neutral', 400)};
@@ -100,19 +41,7 @@ export const textareaSyles = (
 
   &:focus-visible,
   &[data-focus-visible] {
-    border: ${getThemedBorderWidth(200)} solid ${getThemedColor('neutral', 700)};
-    outline: ${getThemedBorderWidth(200)} solid
-      ${getThemedColor('primary', 700)};
-    outline-offset: ${getThemedSpacing(50)};
-    box-shadow:
-      0 0 0 0.125rem ${getThemedColor('neutral', 100)},
-      rgba(0, 0, 0, 0.05) 0 0.125rem 0.125rem 0.25rem;
-  }
-
-  &:active {
-    border: ${getThemedBorderWidth(100)} solid ${getThemedColor('primary', 600)} !important;
-    outline: none !important;
-    box-shadow: 0 0.0625rem 0.125rem 0 #0000000d;
+    ${fieldFocusVisibleStyles}
   }
 
   &[data-invalid] {
@@ -124,7 +53,7 @@ export const textareaSyles = (
     border: ${getThemedBorderWidth(100)} solid ${getThemedColor('neutral', 300)} !important;
   }
 
-  ${value || defaultValue
+  ${isFilled
     ? `
     border: ${getThemedBorderWidth(100)} solid ${getThemedColor('neutral', 700)};
   `

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -123,6 +123,12 @@ export { default as Switch } from './Forms/Controls/Switch'
 export type { SwitchProps } from './Forms/Controls/Switch/types'
 
 // Inputs
+export { default as FieldWrapper } from './Forms/Inputs/FieldWrapper'
+export type {
+  FieldWrapperLabels,
+  FieldWrapperProps,
+  FieldWrapperSize,
+} from './Forms/Inputs/FieldWrapper/types'
 export { default as CheckboxList } from './Forms/Inputs/CheckboxList'
 export type {
   CheckboxListLabel,


### PR DESCRIPTION
What
Standardizes form input layout, spacing, focus rings, and filled-state behavior by introducing a shared FieldWrapper and aligning all Forms inputs (and nested controls) around it.

Why
Input components duplicated label/caption/error markup and used inconsistent margin-based spacing, focus styles, and filled-state logic. Caption spacing was missing on some fields (e.g. TextInput), focus rings varied, and filled styles often only appeared after interaction—leading to uneven UX across the design system.

Changes

 New FieldWrapper (FieldWrapper/index.tsx, styled.ts, types.ts)
  Shared label, caption, error message, and optional footer layout via flex + gap
  Error bar via flex (no absolute positioning / margin hacks)
  field vs group semantics for single controls vs lists/selects
  Exported from src/components/index.ts

Shared :focus-visible mixin
  fieldFocusVisibleStyles / fieldFocusVisibleStyleObject with consistent outline + 0.125rem offset
  Applied across TextInput, Textarea, Select, RichTextEditor, and Checkbox / Radio / Slider controls

Refactored inputs onto FieldWrapper
  TextInput, Textarea, Combobox, Password, InputWithUnits, SliderInput, Select
  CheckboxList, RadioList (group semantics)
  Removed duplicated header / error-bar styles from those components

Filled-state fixes
  Derive filled styles from controlled value and/or defaultValue, not only after user input
  Border color on focus reserved for filled state (not focus alone) on Textarea / Select

Select open / placement polish
  Focus ring on the parent control (constant radius, overflow: visible) so the outline stays rounded while the trigger flattens to join the panel
  Open-state layout shift fixed (border-*-color: transparent instead of removing the border)
  Placement-aware corners, overlay gap (calc(… * -1) for CSS vars), and upward box-shadow when the menu opens above (data-placement^='top')

Misc
  TextInput Storybook story for disabled + default value
  Textarea footer returns null when empty (no empty fragment)
  SliderInput marks mapping handles both number and { value, label } mark types